### PR TITLE
1. Entwurf für die Optimierung der Testdateien

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Optional, TypeAlias
 
 import pytest
 from pyschval.main import (
@@ -30,6 +30,7 @@ ELEMENTS = [
     "pubPlace",
     "respStmt",
     "text",
+    "TEI",
     "width",
 ]
 
@@ -130,17 +131,36 @@ def main_constraints(main_schema: Schema) -> str:
     return create_schematron_stylesheet(extracted_rules, XSLT_FILES["schxslt"])
 
 
+RNG_test_function: TypeAlias = Callable[
+    [str, str, str, bool, bool], Optional[RNGJingValidator]
+]
+
+
 @pytest.fixture(scope="function")
 def test_element_with_rng(
     element_schema: dict[str, str],
     writer: SimpleTEIWriter,
-) -> Callable[[str, str, str, bool], None]:
+) -> RNG_test_function:
     def test_element(
         element_name: str,
         name: str,
         markup: str,
         result: bool,
+        return_validator: bool = False,
     ):
+        """A generic function, which can be used to test a single element against the defined RelaxNG rules.
+
+        Args:
+            element_name (str): The name (without namespace) of the element to test.e
+            name (str): The name of the file to write / the name of the testcase.
+            markup (str): The markup to write to the file.
+            result (bool): The expected result of the validation.
+            return_validator (bool, optional): If True, the validator object is returned. Defaults to False.
+
+        Returns:
+            None: The test passes if the validation result matches the expected result.
+        """
+
         validator = RNGJingValidator()
         writer.write(name, markup)
 
@@ -149,6 +169,10 @@ def test_element_with_rng(
             schema=element_schema[element_name],
             file_pattern=writer.construct_file_pattern(),
         )
+
         assert len(validator.get_invalid()) == (0 if result else 1)
+
+        if return_validator:
+            return validator
 
     return test_element

--- a/test/elements/test_TEI.py
+++ b/test/elements/test_TEI.py
@@ -1,9 +1,6 @@
+from test.conftest import RNG_test_function
+
 import pytest
-from ssrq_cli.validate.xml import RNGJingValidator
-
-from main import Schema
-
-from ..conftest import SimpleTEIWriter
 
 
 @pytest.mark.parametrize(
@@ -36,26 +33,15 @@ from ..conftest import SimpleTEIWriter
     ],
 )
 def test_TEI_main_rng(
-    main_schema: Schema,
-    writer: SimpleTEIWriter,
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
     message: str | None,
 ):
-    validator = RNGJingValidator()
-    writer.write(name, markup)
-
-    validator.validate(
-        sources=writer.parse_files(),
-        schema=main_schema.rng,
-        file_pattern=writer.construct_file_pattern(),
-    )
-
-    assert len(validator.get_invalid()) == 1
-    assert validator.count_valid() == int(result)
-    if message is not None:
-        file_reports = validator.reports[0]
+    rng_test = test_element_with_rng("TEI", name, markup, result, True)
+    if message is not None and rng_test is not None:
+        file_reports = rng_test.reports[0]
         assert isinstance(file_reports.report, list)
         messages = "".join([error.message for error in file_reports.report])
         assert message in messages

--- a/test/elements/test_back.py
+++ b/test/elements/test_back.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from test.conftest import RNG_test_function
 
 import pytest
 
@@ -29,9 +29,9 @@ import pytest
     ],
 )
 def test_back(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("back", name, markup, result)
+    test_element_with_rng("back", name, markup, result, False)

--- a/test/elements/test_body.py
+++ b/test/elements/test_body.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from test.conftest import RNG_test_function
 
 import pytest
 
@@ -39,7 +39,7 @@ import pytest
     ],
 )
 def test_body(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,

--- a/test/elements/test_cell.py
+++ b/test/elements/test_cell.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from test.conftest import RNG_test_function
 
 import pytest
 
@@ -30,9 +30,9 @@ import pytest
     ],
 )
 def test_cell(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("cell", name, markup, result)
+    test_element_with_rng("cell", name, markup, result, False)

--- a/test/elements/test_docImprint.py
+++ b/test/elements/test_docImprint.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from test.conftest import RNG_test_function
 
 import pytest
 
@@ -34,9 +34,9 @@ import pytest
     ],
 )
 def test_docImprint(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("docImprint", name, markup, result)
+    test_element_with_rng("docImprint", name, markup, result, False)

--- a/test/elements/test_graphic.py
+++ b/test/elements/test_graphic.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from test.conftest import RNG_test_function
 
 import pytest
 
@@ -29,9 +29,9 @@ import pytest
     ],
 )
 def test_graphic(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("graphic", name, markup, result)
+    test_element_with_rng("graphic", name, markup, result, False)

--- a/test/elements/test_handShift.py
+++ b/test/elements/test_handShift.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from test.conftest import RNG_test_function
 
 import pytest
 
@@ -44,9 +44,9 @@ import pytest
     ],
 )
 def test_handShift(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("handShift", name, markup, result)
+    test_element_with_rng("handShift", name, markup, result, False)

--- a/test/elements/test_height.py
+++ b/test/elements/test_height.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from test.conftest import RNG_test_function
 
 import pytest
 
@@ -29,9 +29,9 @@ import pytest
     ],
 )
 def test_height(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("height", name, markup, result)
+    test_element_with_rng("height", name, markup, result, False)

--- a/test/elements/test_idno.py
+++ b/test/elements/test_idno.py
@@ -1,5 +1,3 @@
-from typing import Callable
-
 import pytest
 from pyschval.main import (
     SchematronResult,
@@ -7,7 +5,7 @@ from pyschval.main import (
 )
 from saxonche import PySaxonProcessor
 
-from ..conftest import SimpleTEIWriter
+from ..conftest import RNG_test_function, SimpleTEIWriter
 
 
 @pytest.mark.parametrize(
@@ -26,12 +24,12 @@ from ..conftest import SimpleTEIWriter
     ],
 )
 def test_idno(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("idno", name, markup, result)
+    test_element_with_rng("idno", name, markup, result, False)
 
 
 @pytest.mark.parametrize(

--- a/test/elements/test_licence.py
+++ b/test/elements/test_licence.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from test.conftest import RNG_test_function
 
 import pytest
 
@@ -19,9 +19,9 @@ import pytest
     ],
 )
 def test_licence(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("licence", name, markup, result)
+    test_element_with_rng("licence", name, markup, result, False)

--- a/test/elements/test_measure.py
+++ b/test/elements/test_measure.py
@@ -1,5 +1,3 @@
-from typing import Callable
-
 import pytest
 from pyschval.main import (
     SchematronResult,
@@ -7,7 +5,7 @@ from pyschval.main import (
 )
 from saxonche import PySaxonProcessor
 
-from ..conftest import SimpleTEIWriter
+from ..conftest import RNG_test_function, SimpleTEIWriter
 
 
 @pytest.mark.parametrize(
@@ -31,12 +29,12 @@ from ..conftest import SimpleTEIWriter
     ],
 )
 def test_measure(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("measure", name, markup, result)
+    test_element_with_rng("measure", name, markup, result, False)
 
 
 @pytest.mark.parametrize(

--- a/test/elements/test_measureGrp.py
+++ b/test/elements/test_measureGrp.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from test.conftest import RNG_test_function
 
 import pytest
 
@@ -29,9 +29,9 @@ import pytest
     ],
 )
 def test_measureGrp(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("measureGrp", name, markup, result)
+    test_element_with_rng("measureGrp", name, markup, result, False)

--- a/test/elements/test_orgName.py
+++ b/test/elements/test_orgName.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from test.conftest import RNG_test_function
 
 import pytest
 
@@ -29,9 +29,9 @@ import pytest
     ],
 )
 def test_orgName(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("orgName", name, markup, result)
+    test_element_with_rng("orgName", name, markup, result, False)

--- a/test/elements/test_pubPlace.py
+++ b/test/elements/test_pubPlace.py
@@ -1,12 +1,10 @@
-from typing import Callable
-
 import pytest
 from pyschval.main import (
     SchematronResult,
     validate_chunk,
 )
 
-from ..conftest import SimpleTEIWriter
+from ..conftest import RNG_test_function, SimpleTEIWriter
 
 
 @pytest.mark.parametrize(
@@ -30,12 +28,12 @@ from ..conftest import SimpleTEIWriter
     ],
 )
 def test_pubPlace(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("pubPlace", name, markup, result)
+    test_element_with_rng("pubPlace", name, markup, result, False)
 
 
 @pytest.mark.parametrize(

--- a/test/elements/test_respStmt.py
+++ b/test/elements/test_respStmt.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from test.conftest import RNG_test_function
 
 import pytest
 
@@ -34,9 +34,9 @@ import pytest
     ],
 )
 def test_respStmt(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("respStmt", name, markup, result)
+    test_element_with_rng("respStmt", name, markup, result, False)

--- a/test/elements/test_text.py
+++ b/test/elements/test_text.py
@@ -1,12 +1,10 @@
-from typing import Callable
-
 import pytest
 from pyschval.main import (
     SchematronResult,
     validate_chunk,
 )
 
-from ..conftest import SimpleTEIWriter
+from ..conftest import RNG_test_function, SimpleTEIWriter
 
 
 @pytest.mark.parametrize(
@@ -45,12 +43,12 @@ from ..conftest import SimpleTEIWriter
     ],
 )
 def test_text(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("text", name, markup, result)
+    test_element_with_rng("text", name, markup, result, False)
 
 
 @pytest.mark.parametrize(

--- a/test/elements/test_width.py
+++ b/test/elements/test_width.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from test.conftest import RNG_test_function
 
 import pytest
 
@@ -29,9 +29,9 @@ import pytest
     ],
 )
 def test_width(
-    test_element_with_rng: Callable[[str, str, str, bool], None],
+    test_element_with_rng: RNG_test_function,
     name: str,
     markup: str,
     result: bool,
 ):
-    test_element_with_rng("width", name, markup, result)
+    test_element_with_rng("width", name, markup, result, False)


### PR DESCRIPTION
- added generic test function "test_element_with_rng"
- replaced specific test functions with generic one for all element tests except <TEI>

- Der RNG-Test für das Element TEI weicht von den anderen Elementen dadurch ab, dass die Testfunktion 4 Parameter entgegennimmt (message) statt nur drei: Soll hier die generische Funktion um einen optionalen Parameter erweitert werden oder richten wir eine zweite generische Funktion für Tests mit 4 Parametern ein?