### PR TITLE
[feat]: allow unknown values for tei:width|tei:height (see #3118)

### DIFF
--- a/src/common/classes.odd.xml
+++ b/src/common/classes.odd.xml
@@ -333,6 +333,19 @@
             </attList>
         </classSpec>
         <classSpec ident="att.dimensions" type="atts" mode="change">
+            <constraintSpec scheme="schematron" ident="sch-att-dimensions">
+                <desc xml:lang="en" versionDate="2023-05-22">If <att>unit</att> has the value unknown, <att>quantity</att>
+                    must be unknown too.</desc>
+                <constraint>
+                    <sch:pattern>
+                        <sch:rule context="tei:height[@unit = 'unknown']|tei:width[@unit = 'unknown']">
+                            <sch:assert test="./@quantity = 'unknown'" xml:lang="en">When @unit is unknown, @quantity
+                                must be unknown too.
+                            </sch:assert>
+                        </sch:rule>
+                    </sch:pattern>
+                </constraint>
+            </constraintSpec>
             <attList>
                 <attDef ident="unit" mode="replace">
                     <desc xml:lang="de" versionDate="2023-03-17">Masseinheit</desc>
@@ -368,6 +381,7 @@
                                 <rng:param name="minInclusive">0</rng:param>
                             </rng:data>
                             <rng:data type="positiveInteger"/>
+                            <rng:ref name="ssrq.measure.unknown"/>
                         </rng:choice>
                     </datatype>
                     <exemplum type="ssrq-doc-example" xml:lang="de" versionDate="2023-03-17">

--- a/src/common/datatypes.odd.xml
+++ b/src/common/datatypes.odd.xml
@@ -309,6 +309,19 @@
 
     <specGrp xml:id="ssrq-measure">
 
+        <dataSpec ident="ssrq.measure.unknown">
+            <content>
+                <valList type="closed">
+                    <valItem ident="unknown">
+                        <desc xml:lang="de" versionDate="2023-05-22">unbekannt</desc>
+                        <desc xml:lang="en" versionDate="2023-05-22">unknown</desc>
+                        <desc xml:lang="fr" versionDate="2023-05-22">inconnu</desc>
+                        <desc xml:lang="it" versionDate="2023-05-22">sconosciuto</desc>
+                    </valItem>
+                </valList>
+            </content>
+        </dataSpec>
+
         <dataSpec ident="ssrq.measure.lengths.base.cm">
             <content>
                 <valList type="closed">

--- a/src/elements/height.xml
+++ b/src/elements/height.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="height" module="msdescription" mode="change">
-    <desc xml:lang="de" versionDate="2023-03-21">Gibt die Höhe eines Blattes oder Buches wieder (cm).</desc>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="height" module="msdescription" mode="change"
+    xmlns:rng="http://relaxng.org/ns/structure/1.0">
+    <desc xml:lang="de" versionDate="2023-03-21">Gibt die Höhe eines Blattes oder Buches wieder
+        (cm).</desc>
     <desc xml:lang="en" versionDate="2023-03-21">Indicates the height of a sheet or book (cm).</desc>
-    <desc xml:lang="fr" versionDate="2023-03-21">Reflète la hauteur d'une feuille ou d'un livre (cm).</desc>
+    <desc xml:lang="fr" versionDate="2023-03-21">Reflète la hauteur d'une feuille ou d'un livre
+        (cm).</desc>
     <classes mode="replace">
         <memberOf key="model.dimLike"/>
         <memberOf key="model.measureLike"/>
@@ -15,7 +18,10 @@
     <attList>
         <attDef ident="unit" mode="change" usage="req">
             <datatype>
-                <dataRef key="ssrq.measure.lengths.base.cm"/>
+                <rng:choice>
+                    <rng:ref name="ssrq.measure.unknown"/>
+                    <rng:ref name="ssrq.measure.lengths.base.cm"/>
+                </rng:choice>
             </datatype>
         </attDef>
         <attDef ident="quantity" mode="change" usage="req"/>

--- a/src/elements/width.xml
+++ b/src/elements/width.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="width" module="msdescription" mode="change">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="width" module="msdescription" mode="change"
+    xmlns:rng="http://relaxng.org/ns/structure/1.0">
     <desc xml:lang="de" versionDate="2023-03-17">Gibt die Breite eines Blattes oder Buchs sowie die
-        Breite der Plica (cm) wieder.
-    </desc>
+        Breite der Plica (cm) wieder. </desc>
     <desc xml:lang="en" versionDate="2023-03-17">Indicates the width of a leaf or book and the width
-        of the plica (cm).
-    </desc>
+        of the plica (cm). </desc>
     <desc xml:lang="fr" versionDate="2023-03-17">Indique la largeur d'une feuille ou d'un livre,
-        ainsi que celle d'une plica (cm).
-    </desc>
+        ainsi que celle d'une plica (cm). </desc>
     <classes mode="replace">
         <memberOf key="model.dimLike"/>
         <memberOf key="model.measureLike"/>
@@ -21,7 +19,10 @@
     <attList>
         <attDef ident="unit" mode="change" usage="req">
             <datatype>
-                <dataRef key="ssrq.measure.lengths.base.cm"/>
+                <rng:choice>
+                    <rng:ref name="ssrq.measure.unknown"/>
+                    <rng:ref name="ssrq.measure.lengths.base.cm"/>
+                </rng:choice>
             </datatype>
         </attDef>
         <attDef ident="quantity" mode="change" usage="req"/>

--- a/test/elements/test_width.py
+++ b/test/elements/test_width.py
@@ -1,6 +1,10 @@
-from test.conftest import RNG_test_function
+from test.conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
 
 import pytest
+from pyschval.main import (
+    SchematronResult,
+    validate_chunk,
+)
 
 
 @pytest.mark.parametrize(
@@ -35,3 +39,28 @@ def test_width(
     result: bool,
 ):
     test_element_with_rng("width", name, markup, result, False)
+
+
+@pytest.mark.parametrize(
+    "name, markup, result",
+    [
+        (
+            "valid-height-with-unknown-values",
+            "<width quantity='unknown' unit='unknown'/>",
+            True,
+        ),
+        (
+            "invalid-height-with-unknown-values",
+            "<width quantity='1' unit='unknown'/>",
+            False,
+        ),
+    ],
+)
+def test_width_constraints(
+    main_constraints: str, writer: SimpleTEIWriter, name: str, markup: str, result: bool
+):
+    writer.write(name, add_tei_namespace(markup))
+    reports: list[SchematronResult] = validate_chunk(
+        files=writer.list(), isosch=main_constraints
+    )
+    assert reports[0].is_valid() is result


### PR DESCRIPTION
Specs for tei:width and tei:height tweaked – now it's allowed to use unknown as a value for measure.
