### PR TITLE
[fix]: content model tei:origin

### DIFF
--- a/src/elements/origin.xml
+++ b/src/elements/origin.xml
@@ -8,16 +8,22 @@
     document.</desc>
     <desc xml:lang="en" versionDate="2023-05-16">Contains information on the origin
     of a document.</desc>
-    <classes mode="replace"/>
+    <classes mode="replace">
+        <memberOf key="att.global"/>
+    </classes>
     <content>
         <sequence>
-            <alternate minOccurs="1" maxOccurs="1">
-                <elementRef key="foreign"/>
-                <elementRef key="origDate"/>
-            </alternate>
+            <elementRef key="origDate" minOccurs="1" maxOccurs="1"/>
             <elementRef key="origPlace" minOccurs="0" maxOccurs="1"/>
         </sequence>
     </content>
+    <attList>
+        <attDef ident="cert" mode="delete"/>
+        <attDef ident="n" mode="delete"/>
+        <attDef ident="rend" mode="delete"/>
+        <attDef ident="resp" mode="delete"/>
+        <attDef ident="xml:id" mode="delete"/>
+    </attList>
     <exemplum
         type="ssrq-doc-example" versionDate="2023-05-16">
         <p xml:lang="de">Erfassung der Herkunft und der Datierung</p>

--- a/test/elements/test_origin.py
+++ b/test/elements/test_origin.py
@@ -12,6 +12,11 @@ from ..conftest import RNG_test_function
             True,
         ),
         (
+            "valid-origin-with-lang",
+            " <origin xml:lang='de'><origDate when-custom='1366-06-29' calendar='gregorian'/><origPlace>Rheineck</origPlace></origin>",
+            True,
+        ),
+        (
             "invalid-origin-with-note",
             " <origin><origDate when-custom='1366-06-29' calendar='gregorian'/><origPlace>Rheineck</origPlace><note>some text</note></origin>",
             False,


### PR DESCRIPTION
The element tei:foreign is not allowed any longer, instead xml:lang can be used.

