### PR TITLE
[fix]: allowed emtpy tei:sic and tei:corr

### DIFF
--- a/src/common/constraints.odd.xml
+++ b/src/common/constraints.odd.xml
@@ -63,9 +63,9 @@
                 <sch:pattern>
                     <sch:rule
                             context="tei:publisher|tei:pubPlace|tei:*[name() = ('ab', 'abbr', 'add', 'bibl', 'condition',
-                            'corr', 'del', 'expan', 'foreign', 'fw', 'head', 'hi', 'item', 'label', 'lem', 'licence',
+                            'del', 'expan', 'foreign', 'fw', 'head', 'hi', 'item', 'label', 'lem', 'licence',
                             'note', 'num', 'orgName', 'orig', 'p', 'persName', 'placeName', 'q', 'quote', 'repository',
-                            'seg', 'sic', 'signed', 'supplied', 'time', 'title', 'unclear')][not(*)]">
+                            'seg', 'signed', 'supplied', 'time', 'title', 'unclear')][not(*)]">
                         <sch:assert test="string-length(normalize-space(.)) > 0">
                             <sch:name/>
                             should contain some text.

--- a/test/elements/test_corr.py
+++ b/test/elements/test_corr.py
@@ -1,10 +1,6 @@
 import pytest
-from pyschval.main import (
-    SchematronResult,
-    validate_chunk,
-)
 
-from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
+from ..conftest import RNG_test_function
 
 
 @pytest.mark.parametrize(
@@ -39,23 +35,3 @@ def test_corr(
     result: bool,
 ):
     test_element_with_rng("corr", name, markup, result, False)
-
-
-@pytest.mark.parametrize(
-    "name, markup, result",
-    [
-        (
-            "invalid-empty-corr",
-            "<corr/>",
-            False,
-        ),
-    ],
-)
-def test_corr_constraints(
-    main_constraints: str, writer: SimpleTEIWriter, name: str, markup: str, result: bool
-):
-    writer.write(name, add_tei_namespace(markup))
-    reports: list[SchematronResult] = validate_chunk(
-        files=writer.list(), isosch=main_constraints
-    )
-    assert reports[0].is_valid() is result

--- a/test/elements/test_sic.py
+++ b/test/elements/test_sic.py
@@ -40,11 +40,6 @@ def test_sic(
             "<sic>bar</sic>",
             True,
         ),
-        (
-            "invalid-empty-sic",
-            "<sic/>",
-            False,
-        ),
     ],
 )
 def test_sic_constraints(


### PR DESCRIPTION
Wie besprochen sind jetzt leeres sic und corr erlaubt.
Die entsprechenden Tests wurden entfernt.