### PR TITLE
[feat]: split datatypes by lang of valList

### DIFF
--- a/src/common/datatypes.odd.xml
+++ b/src/common/datatypes.odd.xml
@@ -2444,7 +2444,7 @@
                 tedesco)
             </desc>
             <content>
-                <valList type="closed">
+                <valList type="closed" xml:lang="de">
                     <valItem ident="Anlage Register"/>
                     <valItem ident="Erfassung Metadaten im TEI-Header"/>
                     <valItem ident="Erstellung Faksimile"/>
@@ -2466,7 +2466,7 @@
             <desc xml:lang="it" versionDate="2023-06-29">Compiti / Ruoli dei partecipanti al progetto (in francese)
             </desc>
             <content>
-                <valList type="closed">
+                <valList type="closed" xml:lang="fr">
                     <valItem ident="Annexe Registre"/>
                     <valItem ident="Codage XML du transcript"/>
                     <valItem ident="Contrôle de qualité"/>

--- a/utils/specs/base.py
+++ b/utils/specs/base.py
@@ -237,8 +237,7 @@ class BaseSpec:
                     elements_found.append(key_or_name)
 
             if split_tag_and_ns(content_part.tag)[1] == "valList":
-                val_items = content_part.findall("./tei:valItem", namespaces=NS_MAP)
-                elements_found.extend(val_items)
+                elements_found.append(content_part)
 
             if split_tag_and_ns(content_part.tag)[1] == "textNode":
                 elements_found.append("textNode")

--- a/utils/specs/element.py
+++ b/utils/specs/element.py
@@ -104,7 +104,7 @@ class ElementSpec(BaseSpec):
             doc.add_paragraph(translations["isEmpty"])
             return None
 
-        content_keys, val_items = [i for i in self.content if isinstance(i, str)], [
+        content_keys, vallists = [i for i in self.content if isinstance(i, str)], [
             i for i in self.content if isinstance(i, ET.Element)
         ]
 
@@ -129,12 +129,13 @@ class ElementSpec(BaseSpec):
 
         doc.add_unordered_list(chain(contents_elements or [], text_elements or []))
 
-        self.val_items_to_markdown(
-            val_items=val_items,
-            doc=doc,
-            translations=translations,
-            lang=lang,
-        )
+        if len(vallists) > 0:
+            self.val_items_to_markdown(
+                val_items=self._filter_vallists_by_lang(vallists=vallists, lang=lang),
+                doc=doc,
+                translations=translations,
+                lang=lang,
+            )
 
     def _list_examples(
         self, translations: dict[str, str], lang: str, doc: Document
@@ -179,6 +180,19 @@ class ElementSpec(BaseSpec):
             doc.add_heading(desc_title, level=2)
         doc.add_raw(self.get_desc(element=el, lang=lang))
 
+    def _filter_vallists_by_lang(
+        self, vallists: list[ET.Element], lang: str
+    ) -> list[ET.Element]:
+        val_items = []
+
+        for vallist in vallists:
+            xml_lang = vallist.get(f"{{{NS_MAP['xml']}}}lang")
+
+            if xml_lang is None or xml_lang == lang:
+                val_items.extend(vallist.findall(".//tei:valItem", namespaces=NS_MAP))
+
+        return val_items
+
     def val_items_to_markdown(
         self,
         val_items: list[ET.Element],
@@ -186,18 +200,17 @@ class ElementSpec(BaseSpec):
         lang: str,
         translations: dict[str, str],
     ) -> None:
-        if len(val_items) > 0:
-            doc.add_paragraph(f"**{translations['restrictedValues']}**")
+        doc.add_paragraph(f"**{translations['restrictedValues']}**")
 
-            sorted_valItems = sorted(val_items, key=lambda x: x.attrib["ident"])
-            content_values = []
+        sorted_valItems = sorted(val_items, key=lambda x: x.attrib["ident"])
+        content_values = []
 
-            for valItem in sorted_valItems:
-                content_values.append(
-                    f"{valItem.attrib['ident']}{': ' + desc if len((desc := self.get_desc(element=valItem, lang=lang))) > 0 else ''}"
-                )
+        for val_item in sorted_valItems:
+            content_values.append(
+                f"{val_item.attrib['ident']}{': ' + desc if len((desc := self.get_desc(element=val_item, lang=lang))) > 0 else ''}"
+            )
 
-            doc.add_unordered_list(content_values)
+        doc.add_unordered_list(content_values)
 
     def _group_content_by_model(self, elements: dict[str, Self], content: list[str]):
         elements_by_model: dict[str, list[str]] = {}


### PR DESCRIPTION
The initial idea was to split the values by the ident attribute of of the tei:dataSpec-element. This seems to be a bad idea. Instead now a lang-attribute is used on the vallist, which is used for filtering, when the docs are rendered. At the moment this is just used for rendering the possible content of elements.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

See the description of the commit.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality).
- [x] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
