### PR TITLE
[fix]: remove unnecessary attribute `@xml:id`

### DIFF
--- a/src/elements/fileDesc.xml
+++ b/src/elements/fileDesc.xml
@@ -52,7 +52,7 @@
                         </licence>
                     </availability>
                 </publicationStmt>
-                <seriesStmt xml:id="ssrq-sds-fds">
+                <seriesStmt>
                     <title>Sammlung Schweizerischer Rechtsquellen</title>
                     <respStmt>
                         <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
@@ -127,7 +127,7 @@
                         </licence>
                     </availability>
                 </publicationStmt>
-                <seriesStmt xml:id="ssrq-sds-fds">
+                <seriesStmt>
                     <title>Sammlung Schweizerischer Rechtsquellen</title>
                     <respStmt>
                         <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>

--- a/src/elements/idno.xml
+++ b/src/elements/idno.xml
@@ -89,7 +89,7 @@
     <exemplum xml:lang="de" type="ssrq-doc-example" versionDate="2023-03-03">
         <p>Definition der Identifikationsnummer eines Stücks:</p>
         <egXML xmlns="http://www.tei-c.org/ns/Examples">
-            <seriesStmt xml:id="ssrq-sds-fds">
+            <seriesStmt>
                 <title>Sammlung Schweizerischer Rechtsquellen</title>
                 <respStmt>
                     <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
@@ -103,7 +103,7 @@
     <exemplum xml:lang="fr" type="ssrq-doc-example" versionDate="2023-03-03">
         <p>Définition du numéro d'identification d'une pièce :</p>
         <egXML xmlns="http://www.tei-c.org/ns/Examples">
-            <seriesStmt xml:id="ssrq-sds-fds">
+            <seriesStmt>
                 <title>Sammlung Schweizerischer Rechtsquellen</title>
                 <respStmt>
                     <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>

--- a/src/elements/seriesStmt.xml
+++ b/src/elements/seriesStmt.xml
@@ -23,9 +23,7 @@
     <desc xml:lang="it" versionDate="2023-04-21">Contiene elementi per descrivere la collezione delle serie di fonti
         giuridiche svizzere.
     </desc>
-    <classes mode="replace">
-        <memberOf key="att.global"/>
-    </classes>
+    <classes mode="replace"/>
     <content>
         <sequence>
             <elementRef key="title"/>
@@ -33,18 +31,9 @@
             <elementRef key="idno" minOccurs="2" maxOccurs="2"/>
         </sequence>
     </content>
-    <attList>
-        <attDef ident="n" mode="delete"/>
-        <attDef ident="xml:id" mode="replace" usage="req">
-            <valList type="closed">
-                <valItem ident="ssrq-sds-fds"/>
-            </valList>
-        </attDef>
-        <attDef ident="xml:lang" mode="delete"/>
-    </attList>
     <exemplum xml:lang="de" type="ssrq-doc-example" versionDate="2023-04-21">
         <egXML xmlns="http://www.tei-c.org/ns/Examples">
-            <seriesStmt xml:id="ssrq-sds-fds">
+            <seriesStmt>
                 <title>Sammlung Schweizerischer Rechtsquellen</title>
                 <respStmt>
                     <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
@@ -57,7 +46,7 @@
     </exemplum>
     <exemplum xml:lang="fr" type="ssrq-doc-example" versionDate="2023-04-21">
         <egXML xmlns="http://www.tei-c.org/ns/Examples">
-            <seriesStmt xml:id="ssrq-sds-fds">
+            <seriesStmt>
                 <title>Sammlung Schweizerischer Rechtsquellen</title>
                 <respStmt>
                     <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>

--- a/src/elements/teiHeader.xml
+++ b/src/elements/teiHeader.xml
@@ -48,7 +48,7 @@
                             </licence>
                         </availability>
                     </publicationStmt>
-                    <seriesStmt xml:id="ssrq-sds-fds">
+                    <seriesStmt>
                         <title>Sammlung Schweizerischer Rechtsquellen</title>
                         <respStmt>
                             <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>

--- a/test/elements/test_TEI.py
+++ b/test/elements/test_TEI.py
@@ -9,177 +9,177 @@ import pytest
         (
             "TEI-valid",
             """<TEI xml:lang="de">
-                                            <teiHeader>
-                                                <fileDesc>
-                                                    <titleStmt>
-                                                        <title>foo</title>
-                                                        <editor>
-                                                        <persName>Michael Nadig</persName>
-                                                        </editor>
-                                                        <respStmt>
-                                                        <persName>Ariane Huber Hernández</persName>
-                                                        <persName>Michael Nadig</persName>
-                                                        <resp>Transkription</resp>
-                                                        </respStmt>
-                                                    </titleStmt>
-                                                    <publicationStmt>
-                                                        <publisher>SSRQ-SDS-FDS</publisher>
-                                                        <availability>
-                                                        <licence target="https://creativecommons.org/licenses/by-nc-sa/4.0/"
-                                                            >Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA
-                                                            4.0)</licence>
-                                                        </availability>
-                                                    </publicationStmt>
-                                                    <seriesStmt xml:id="ssrq-sds-fds">
-                                                        <title>Sammlung Schweizerischer Rechtsquellen</title>
-                                                        <respStmt>
-                                                            <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
-                                                            <resp>Herausgabe</resp>
-                                                        </respStmt>
-                                                        <idno>SSRQ-FR-I_2_8-1-1</idno>
-                                                        <idno type="uuid">ad28656b-5c8d-459c-afb4-3e6ddf70810d</idno>
-                                                    </seriesStmt>
-                                                    <sourceDesc>
-                                                        <msDesc>
-                                                        <msIdentifier>
-                                                            <idno xml:lang="de" source="http://foo.bar">bar</idno>
-                                                            <repository xml:lang="de">foo</repository>
-                                                        </msIdentifier>
-                                                        <head>Projekt eines Eides für den Förster oder Bannwart in Sax-Forstegg</head>
-                                                        <msContents>
-                                                            <summary>
-                                                                <p xml:lang="de">foo</p>
-                                                            </summary>
-                                                            <msItem>
-                                                                <textLang xml:lang="de"/>
-                                                            </msItem>
-                                                        </msContents>
-                                                        <physDesc>
-                                                            <objectDesc form='copy'>
-                                                                <supportDesc>
-                                                                    <support>
-                                                                    <material type="paper"/>
-                                                                    </support>
-                                                                    <extent>
-                                                                    <dimensions type="leaves">
-                                                                        <height unit="cm" quantity="36.0"/>
-                                                                        <width unit="cm" quantity="23.5"/>
-                                                                    </dimensions>
-                                                                    </extent>
-                                                                </supportDesc>
-                                                            </objectDesc>
-                                                        </physDesc>
-                                                        <history>
-                                                            <origin>
-                                                                <origDate from-custom="1615-04-15" to-custom="1700-12-31" calendar="unknown"/>
-                                                            </origin>
-                                                        </history>
-                                                        </msDesc>
-                                                    </sourceDesc>
-                                                </fileDesc>
-                                                <encodingDesc>
-                                            <editorialDecl>
-                                                <p>
-                                                    <ref target="https://www.ssrq-sds-fds.ch/wiki/Transkriptionsrichtlinien"/>
-                                                </p>
-                                            </editorialDecl>
-                                        </encodingDesc>
-                                            </teiHeader>
-                                            <text type='transcript'>
-                                                <body>
-                                                    <div><p>foo</p></div>
-                                                </body>
-                                            </text>
-                                            </TEI>""",
+                                                <teiHeader>
+                                                    <fileDesc>
+                                                        <titleStmt>
+                                                            <title>foo</title>
+                                                            <editor>
+                                                            <persName>Michael Nadig</persName>
+                                                            </editor>
+                                                            <respStmt>
+                                                            <persName>Ariane Huber Hernández</persName>
+                                                            <persName>Michael Nadig</persName>
+                                                            <resp>Transkription</resp>
+                                                            </respStmt>
+                                                        </titleStmt>
+                                                        <publicationStmt>
+                                                            <publisher>SSRQ-SDS-FDS</publisher>
+                                                            <availability>
+                                                            <licence target="https://creativecommons.org/licenses/by-nc-sa/4.0/"
+                                                                >Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA
+                                                                4.0)</licence>
+                                                            </availability>
+                                                        </publicationStmt>
+                                                        <seriesStmt>
+                                                            <title>Sammlung Schweizerischer Rechtsquellen</title>
+                                                            <respStmt>
+                                                                <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
+                                                                <resp>Herausgabe</resp>
+                                                            </respStmt>
+                                                            <idno>SSRQ-FR-I_2_8-1-1</idno>
+                                                            <idno type="uuid">ad28656b-5c8d-459c-afb4-3e6ddf70810d</idno>
+                                                        </seriesStmt>
+                                                        <sourceDesc>
+                                                            <msDesc>
+                                                            <msIdentifier>
+                                                                <idno xml:lang="de" source="http://foo.bar">bar</idno>
+                                                                <repository xml:lang="de">foo</repository>
+                                                            </msIdentifier>
+                                                            <head>Projekt eines Eides für den Förster oder Bannwart in Sax-Forstegg</head>
+                                                            <msContents>
+                                                                <summary>
+                                                                    <p xml:lang="de">foo</p>
+                                                                </summary>
+                                                                <msItem>
+                                                                    <textLang xml:lang="de"/>
+                                                                </msItem>
+                                                            </msContents>
+                                                            <physDesc>
+                                                                <objectDesc form='copy'>
+                                                                    <supportDesc>
+                                                                        <support>
+                                                                        <material type="paper"/>
+                                                                        </support>
+                                                                        <extent>
+                                                                        <dimensions type="leaves">
+                                                                            <height unit="cm" quantity="36.0"/>
+                                                                            <width unit="cm" quantity="23.5"/>
+                                                                        </dimensions>
+                                                                        </extent>
+                                                                    </supportDesc>
+                                                                </objectDesc>
+                                                            </physDesc>
+                                                            <history>
+                                                                <origin>
+                                                                    <origDate from-custom="1615-04-15" to-custom="1700-12-31" calendar="unknown"/>
+                                                                </origin>
+                                                            </history>
+                                                            </msDesc>
+                                                        </sourceDesc>
+                                                    </fileDesc>
+                                                    <encodingDesc>
+                                                <editorialDecl>
+                                                    <p>
+                                                        <ref target="https://www.ssrq-sds-fds.ch/wiki/Transkriptionsrichtlinien"/>
+                                                    </p>
+                                                </editorialDecl>
+                                            </encodingDesc>
+                                                </teiHeader>
+                                                <text type='transcript'>
+                                                    <body>
+                                                        <div><p>foo</p></div>
+                                                    </body>
+                                                </text>
+                                                </TEI>""",
             True,
             None,
         ),
         (
             "invalid-TEI-with-two-texts",
             """<TEI xml:lang="de">
-                                            <teiHeader>
-                                                <fileDesc>
-                                                    <titleStmt>
-                                                        <title>foo</title>
-                                                        <editor>
-                                                        <persName>Michael Nadig</persName>
-                                                        </editor>
-                                                        <respStmt>
-                                                        <persName>Ariane Huber Hernández</persName>
-                                                        <persName>Michael Nadig</persName>
-                                                        <resp>Transkription</resp>
-                                                        </respStmt>
-                                                    </titleStmt>
-                                                    <publicationStmt>
-                                                        <publisher>SSRQ-SDS-FDS</publisher>
-                                                        <availability>
-                                                            <licence target="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-                                                                Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)
-                                                            </licence>
-                                                        </availability>
-                                                    </publicationStmt>
-                                                    <seriesStmt xml:id="ssrq-sds-fds">
-                                                        <title>Sammlung Schweizerischer Rechtsquellen</title>
-                                                        <respStmt>
-                                                            <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
-                                                            <resp>Herausgabe</resp>
-                                                        </respStmt>
-                                                        <idno>SSRQ-FR-I_2_8-1-1</idno>
-                                                        <idno type="uuid">ad28656b-5c8d-459c-afb4-3e6ddf70810d</idno>
-                                                    </seriesStmt>
-                                                    <sourceDesc>
-                                                        <msDesc>
-                                                        <msIdentifier>
-                                                            <idno xml:lang="de" source="http://foo.bar">bar</idno>
-                                                            <repository xml:lang="de">foo</repository>
-                                                        </msIdentifier>
-                                                        <head>Projekt eines Eides für den Förster oder Bannwart in Sax-Forstegg</head>
-                                                        <msContents>
-                                                            <summary>
-                                                                <p xml:lang="de">foo</p>
-                                                            </summary>
-                                                            <msItem>
-                                                                <textLang xml:lang="de"/>
-                                                            </msItem>
-                                                        </msContents>
-                                                        <physDesc>
-                                                            <objectDesc form='copy'>
-                                                                <supportDesc>
-                                                                    <support>
-                                                                    <material type="paper"/>
-                                                                    </support>
-                                                                    <extent>
-                                                                    <dimensions type="leaves">
-                                                                        <height unit="cm" quantity="36.0"/>
-                                                                        <width unit="cm" quantity="23.5"/>
-                                                                    </dimensions>
-                                                                    </extent>
-                                                                </supportDesc>
-                                                            </objectDesc>
-                                                        </physDesc>
-                                                        <history>
-                                                            <origin>
-                                                                <origDate from-custom="1615-04-15" to-custom="1700-12-31" calendar="unknown"/>
-                                                            </origin>
-                                                        </history>
-                                                        </msDesc>
-                                                    </sourceDesc>
-                                                </fileDesc>
-                                                <encodingDesc>
-                                            <editorialDecl>
-                                                <p>
-                                                    <ref target="https://www.ssrq-sds-fds.ch/wiki/Transkriptionsrichtlinien"/>
-                                                </p>
-                                            </editorialDecl>
-                                        </encodingDesc>
-                                            </teiHeader>
-                                            <text type='transcript'>
-                                                <body><div><p>foo</p></div></body>
-                                            </text>
-                                            <text type='summary'>
-                                                <body><div><p>foo</p></div></body>
-                                            </text>
-                                            </TEI>""",
+                                                <teiHeader>
+                                                    <fileDesc>
+                                                        <titleStmt>
+                                                            <title>foo</title>
+                                                            <editor>
+                                                            <persName>Michael Nadig</persName>
+                                                            </editor>
+                                                            <respStmt>
+                                                            <persName>Ariane Huber Hernández</persName>
+                                                            <persName>Michael Nadig</persName>
+                                                            <resp>Transkription</resp>
+                                                            </respStmt>
+                                                        </titleStmt>
+                                                        <publicationStmt>
+                                                            <publisher>SSRQ-SDS-FDS</publisher>
+                                                            <availability>
+                                                                <licence target="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+                                                                    Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)
+                                                                </licence>
+                                                            </availability>
+                                                        </publicationStmt>
+                                                        <seriesStmt>
+                                                            <title>Sammlung Schweizerischer Rechtsquellen</title>
+                                                            <respStmt>
+                                                                <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
+                                                                <resp>Herausgabe</resp>
+                                                            </respStmt>
+                                                            <idno>SSRQ-FR-I_2_8-1-1</idno>
+                                                            <idno type="uuid">ad28656b-5c8d-459c-afb4-3e6ddf70810d</idno>
+                                                        </seriesStmt>
+                                                        <sourceDesc>
+                                                            <msDesc>
+                                                            <msIdentifier>
+                                                                <idno xml:lang="de" source="http://foo.bar">bar</idno>
+                                                                <repository xml:lang="de">foo</repository>
+                                                            </msIdentifier>
+                                                            <head>Projekt eines Eides für den Förster oder Bannwart in Sax-Forstegg</head>
+                                                            <msContents>
+                                                                <summary>
+                                                                    <p xml:lang="de">foo</p>
+                                                                </summary>
+                                                                <msItem>
+                                                                    <textLang xml:lang="de"/>
+                                                                </msItem>
+                                                            </msContents>
+                                                            <physDesc>
+                                                                <objectDesc form='copy'>
+                                                                    <supportDesc>
+                                                                        <support>
+                                                                        <material type="paper"/>
+                                                                        </support>
+                                                                        <extent>
+                                                                        <dimensions type="leaves">
+                                                                            <height unit="cm" quantity="36.0"/>
+                                                                            <width unit="cm" quantity="23.5"/>
+                                                                        </dimensions>
+                                                                        </extent>
+                                                                    </supportDesc>
+                                                                </objectDesc>
+                                                            </physDesc>
+                                                            <history>
+                                                                <origin>
+                                                                    <origDate from-custom="1615-04-15" to-custom="1700-12-31" calendar="unknown"/>
+                                                                </origin>
+                                                            </history>
+                                                            </msDesc>
+                                                        </sourceDesc>
+                                                    </fileDesc>
+                                                    <encodingDesc>
+                                                <editorialDecl>
+                                                    <p>
+                                                        <ref target="https://www.ssrq-sds-fds.ch/wiki/Transkriptionsrichtlinien"/>
+                                                    </p>
+                                                </editorialDecl>
+                                            </encodingDesc>
+                                                </teiHeader>
+                                                <text type='transcript'>
+                                                    <body><div><p>foo</p></div></body>
+                                                </text>
+                                                <text type='summary'>
+                                                    <body><div><p>foo</p></div></body>
+                                                </text>
+                                                </TEI>""",
             False,
             None,
         ),

--- a/test/elements/test_fileDesc.py
+++ b/test/elements/test_fileDesc.py
@@ -9,136 +9,136 @@ import pytest
         (
             "valid-fileDesc",
             """<fileDesc>
-                    <titleStmt>
-                        <title>foo</title>
-                        <editor>
-                            <persName>Michael Nadig</persName>
-                        </editor>
-                        <respStmt>
-                            <persName>Ariane Huber Hernández</persName>
-                            <persName>Michael Nadig</persName>
-                            <resp>Transkription</resp>
-                        </respStmt>
-                    </titleStmt>
-                    <publicationStmt>
-                        <publisher>SSRQ-SDS-FDS</publisher>
-                        <availability>
-                            <licence target="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-                                Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)
-                            </licence>
-                        </availability>
-                    </publicationStmt>
-                    <seriesStmt xml:id="ssrq-sds-fds">
-                        <title>Sammlung Schweizerischer Rechtsquellen</title>
-                        <respStmt>
-                            <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
-                            <resp>Herausgabe</resp>
-                        </respStmt>
-                        <idno>SSRQ-FR-I_2_8-1-1</idno>
-                        <idno type="uuid">ad28656b-5c8d-459c-afb4-3e6ddf70810d</idno>
-                    </seriesStmt>
-                    <sourceDesc>
-                        <msDesc>
-                            <msIdentifier>
-                                <idno xml:lang="de" source="http://foo.bar">bar</idno>
-                                <repository xml:lang="de">foo</repository>
-                            </msIdentifier>
-                            <head>Projekt eines Eides für den Förster oder Bannwart in
-                                Sax-Forstegg</head>
-                            <msContents>
-                                <summary>
-                                    <p xml:lang="de">foo</p>
-                                </summary>
-                                <msItem>
-                                    <textLang xml:lang="de"/>
-                                </msItem>
-                            </msContents>
-                            <physDesc>
-                                <objectDesc form='copy'>
-                                    <supportDesc>
-                                        <support>
-                                            <material type="paper"/>
-                                        </support>
-                                        <extent>
-                                            <dimensions type="leaves">
-                                                <height unit="cm" quantity="36.0"/>
-                                                <width unit="cm" quantity="23.5"/>
-                                            </dimensions>
-                                        </extent>
-                                    </supportDesc>
-                                </objectDesc>
-                            </physDesc>
-                            <history>
-                                <origin>
-                                    <origDate calendar='gregorian' from-custom="1615-04-15" to-custom="1700-12-31"/>
-                                </origin>
-                            </history>
-                        </msDesc>
-                    </sourceDesc>
-                </fileDesc>""",
+                                <titleStmt>
+                                    <title>foo</title>
+                                    <editor>
+                                        <persName>Michael Nadig</persName>
+                                    </editor>
+                                    <respStmt>
+                                        <persName>Ariane Huber Hernández</persName>
+                                        <persName>Michael Nadig</persName>
+                                        <resp>Transkription</resp>
+                                    </respStmt>
+                                </titleStmt>
+                                <publicationStmt>
+                                    <publisher>SSRQ-SDS-FDS</publisher>
+                                    <availability>
+                                        <licence target="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+                                            Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)
+                                        </licence>
+                                    </availability>
+                                </publicationStmt>
+                                <seriesStmt>
+                                    <title>Sammlung Schweizerischer Rechtsquellen</title>
+                                    <respStmt>
+                                        <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
+                                        <resp>Herausgabe</resp>
+                                    </respStmt>
+                                    <idno>SSRQ-FR-I_2_8-1-1</idno>
+                                    <idno type="uuid">ad28656b-5c8d-459c-afb4-3e6ddf70810d</idno>
+                                </seriesStmt>
+                                <sourceDesc>
+                                    <msDesc>
+                                        <msIdentifier>
+                                            <idno xml:lang="de" source="http://foo.bar">bar</idno>
+                                            <repository xml:lang="de">foo</repository>
+                                        </msIdentifier>
+                                        <head>Projekt eines Eides für den Förster oder Bannwart in
+                                            Sax-Forstegg</head>
+                                        <msContents>
+                                            <summary>
+                                                <p xml:lang="de">foo</p>
+                                            </summary>
+                                            <msItem>
+                                                <textLang xml:lang="de"/>
+                                            </msItem>
+                                        </msContents>
+                                        <physDesc>
+                                            <objectDesc form='copy'>
+                                                <supportDesc>
+                                                    <support>
+                                                        <material type="paper"/>
+                                                    </support>
+                                                    <extent>
+                                                        <dimensions type="leaves">
+                                                            <height unit="cm" quantity="36.0"/>
+                                                            <width unit="cm" quantity="23.5"/>
+                                                        </dimensions>
+                                                    </extent>
+                                                </supportDesc>
+                                            </objectDesc>
+                                        </physDesc>
+                                        <history>
+                                            <origin>
+                                                <origDate calendar='gregorian' from-custom="1615-04-15" to-custom="1700-12-31"/>
+                                            </origin>
+                                        </history>
+                                    </msDesc>
+                                </sourceDesc>
+                            </fileDesc>""",
             True,
         ),
         (
             "invalid-fileDesc-with-missing-seriesStmt",
             """<fileDesc>
-                    <titleStmt>
-                        <title>foo</title>
-                        <editor>
-                            <persName>Michael Nadig</persName>
-                        </editor>
-                        <respStmt>
-                            <persName>Ariane Huber Hernández</persName>
-                            <persName>Michael Nadig</persName>
-                            <resp>Transkription</resp>
-                        </respStmt>
-                    </titleStmt>
-                    <publicationStmt>
-                        <publisher>SSRQ-SDS-FDS</publisher>
-                        <availability>
-                            <licence target="https://creativecommons.org/licenses/by-nc-sa/4.0/"
-                                >Attribution-NonCommercial- ShareAlike 4.0 International (CC BY-NC-SA
-                                4.0)</licence>
-                        </availability>
-                    </publicationStmt>
-                    <sourceDesc>
-                        <msDesc>
-                            <msIdentifier>
-                                <idno xml:lang="de" source="http://foo.bar">bar</idno>
-                                <repository xml:lang="de">foo</repository>
-                            </msIdentifier>
-                            <head>Projekt eines Eides für den Förster oder Bannwart in
-                                Sax-Forstegg</head>
-                            <msContents>
-                                <summary>
-                                    <p xml:lang="de">foo</p>
-                                </summary>
-                                <msItem>
-                                    <textLang xml:lang="de"/>
-                                </msItem>
-                            </msContents>
-                            <physDesc>
-                                <objectDesc>
-                                    <supportDesc>
-                                        <support>
-                                            <material type="paper"/>
-                                        </support>
-                                        <extent>
-                                            <dimensions type="leaves">
-                                                <height unit="cm" quantity="36.0"/>
-                                                <width unit="cm" quantity="23.5"/>
-                                            </dimensions>
-                                        </extent>
-                                    </supportDesc>
-                                </objectDesc>
-                            </physDesc>
-                            <history>
-                                <origin>
-                                    <origDate calendar="unknown" from-custom="1615-04-15" to-custom="1700-12-31"/>
-                                </origin>
-                            </history>
-                        </msDesc>
-                    </sourceDesc>
-                </fileDesc>""",
+                        <titleStmt>
+                            <title>foo</title>
+                            <editor>
+                                <persName>Michael Nadig</persName>
+                            </editor>
+                            <respStmt>
+                                <persName>Ariane Huber Hernández</persName>
+                                <persName>Michael Nadig</persName>
+                                <resp>Transkription</resp>
+                            </respStmt>
+                        </titleStmt>
+                        <publicationStmt>
+                            <publisher>SSRQ-SDS-FDS</publisher>
+                            <availability>
+                                <licence target="https://creativecommons.org/licenses/by-nc-sa/4.0/"
+                                    >Attribution-NonCommercial- ShareAlike 4.0 International (CC BY-NC-SA
+                                    4.0)</licence>
+                            </availability>
+                        </publicationStmt>
+                        <sourceDesc>
+                            <msDesc>
+                                <msIdentifier>
+                                    <idno xml:lang="de" source="http://foo.bar">bar</idno>
+                                    <repository xml:lang="de">foo</repository>
+                                </msIdentifier>
+                                <head>Projekt eines Eides für den Förster oder Bannwart in
+                                    Sax-Forstegg</head>
+                                <msContents>
+                                    <summary>
+                                        <p xml:lang="de">foo</p>
+                                    </summary>
+                                    <msItem>
+                                        <textLang xml:lang="de"/>
+                                    </msItem>
+                                </msContents>
+                                <physDesc>
+                                    <objectDesc>
+                                        <supportDesc>
+                                            <support>
+                                                <material type="paper"/>
+                                            </support>
+                                            <extent>
+                                                <dimensions type="leaves">
+                                                    <height unit="cm" quantity="36.0"/>
+                                                    <width unit="cm" quantity="23.5"/>
+                                                </dimensions>
+                                            </extent>
+                                        </supportDesc>
+                                    </objectDesc>
+                                </physDesc>
+                                <history>
+                                    <origin>
+                                        <origDate calendar="unknown" from-custom="1615-04-15" to-custom="1700-12-31"/>
+                                    </origin>
+                                </history>
+                            </msDesc>
+                        </sourceDesc>
+                    </fileDesc>""",
             False,
         ),
     ],

--- a/test/elements/test_seriesStmt.py
+++ b/test/elements/test_seriesStmt.py
@@ -8,52 +8,52 @@ from ..conftest import RNG_test_function
     [
         (
             "valid-seriesStmt",
-            """<seriesStmt xml:id='ssrq-sds-fds'>
-                <title>Sammlung Schweizerischer Rechtsquellen</title>
-                <respStmt>
-                    <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
-                    <resp>Herausgabe</resp>
-                </respStmt>
-                <idno>SSRQ-FR-I_2_8-1-1</idno>
-                <idno type='uuid'>ad28656b-5c8d-459c-afb4-3e6ddf70810d</idno>
-            </seriesStmt>""",
+            """<seriesStmt>
+                    <title>Sammlung Schweizerischer Rechtsquellen</title>
+                    <respStmt>
+                        <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
+                        <resp>Herausgabe</resp>
+                    </respStmt>
+                    <idno>SSRQ-FR-I_2_8-1-1</idno>
+                    <idno type='uuid'>ad28656b-5c8d-459c-afb4-3e6ddf70810d</idno>
+                </seriesStmt>""",
             True,
         ),
         (
             "invalid-seriesStmt-with-missing-title",
-            """<seriesStmt xml:id='ssrq-sds-fds'>
-                <respStmt>
-                    <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
-                    <resp>Herausgabe</resp>
-                </respStmt>
-                <idno>SSRQ-FR-I_2_8-1-1</idno>
-                <idno type='uuid'>ad28656b-5c8d-459c-afb4-3e6ddf70810d</idno>
-            </seriesStmt>""",
+            """<seriesStmt>
+                    <respStmt>
+                        <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
+                        <resp>Herausgabe</resp>
+                    </respStmt>
+                    <idno>SSRQ-FR-I_2_8-1-1</idno>
+                    <idno type='uuid'>ad28656b-5c8d-459c-afb4-3e6ddf70810d</idno>
+                </seriesStmt>""",
             False,
         ),
         (
             "invalid-seriesStmt-with-one-idno",
-            """<seriesStmt xml:id='ssrq-sds-fds'>
-                <title>Sammlung Schweizerischer Rechtsquellen</title>
-                <respStmt>
-                    <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
-                    <resp>Herausgabe</resp>
-                </respStmt>
-                <idno>SSRQ-FR-I_2_8-1-1</idno>
-            </seriesStmt>""",
+            """<seriesStmt>
+                    <title>Sammlung Schweizerischer Rechtsquellen</title>
+                    <respStmt>
+                        <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
+                        <resp>Herausgabe</resp>
+                    </respStmt>
+                    <idno>SSRQ-FR-I_2_8-1-1</idno>
+                </seriesStmt>""",
             False,
         ),
         (
-            "invalid-seriesStmt-with-wrong-xml-id",
+            "invalid-seriesStmt-with-xml-id",
             """<seriesStmt xml:id='foo'>
-                <title>Sammlung Schweizerischer Rechtsquellen</title>
-                <respStmt>
-                    <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
-                    <resp>Herausgabe</resp>
-                </respStmt>
-                <idno>SSRQ-FR-I_2_8-1-1</idno>
-                <idno type='uuid'>ad28656b-5c8d-459c-afb4-3e6ddf70810d</idno>
-            </seriesStmt>""",
+                    <title>Sammlung Schweizerischer Rechtsquellen</title>
+                    <respStmt>
+                        <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
+                        <resp>Herausgabe</resp>
+                    </respStmt>
+                    <idno>SSRQ-FR-I_2_8-1-1</idno>
+                    <idno type='uuid'>ad28656b-5c8d-459c-afb4-3e6ddf70810d</idno>
+                </seriesStmt>""",
             False,
         ),
     ],

--- a/test/elements/test_teiHeader.py
+++ b/test/elements/test_teiHeader.py
@@ -9,114 +9,114 @@ from ..conftest import RNG_test_function
         (
             "valid-teiHeader",
             """<teiHeader>
-                    <fileDesc>
-                        <titleStmt>
-                            <title>foo</title>
-                            <editor>
-                                <persName>Michael Nadig</persName>
-                            </editor>
-                            <respStmt>
-                                <persName>Ariane Huber Hernández</persName>
-                                <persName>Michael Nadig</persName>
-                                <resp>Transkription</resp>
-                            </respStmt>
-                        </titleStmt>
-                        <publicationStmt>
-                            <publisher>SSRQ-SDS-FDS</publisher>
-                            <availability>
-                                <licence target="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-                                    Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)
-                                </licence>
-                            </availability>
-                        </publicationStmt>
-                        <seriesStmt xml:id="ssrq-sds-fds">
-                            <title>Sammlung Schweizerischer Rechtsquellen</title>
-                            <respStmt>
-                                <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
-                                <resp>Herausgabe</resp>
-                            </respStmt>
-                            <idno>SSRQ-FR-I_2_8-1-1</idno>
-                            <idno type="uuid">ad28656b-5c8d-459c-afb4-3e6ddf70810d</idno>
-                        </seriesStmt>
-                        <sourceDesc>
-                            <msDesc>
-                                <msIdentifier>
-                                    <idno xml:lang="de" source="http://foo.bar">bar</idno>
-                                    <repository xml:lang="de">foo</repository>
-                                </msIdentifier>
-                                <head>Projekt eines Eides für den Förster oder Bannwart in Sax-Forstegg</head>
-                                <msContents>
-                                    <summary>
-                                        <p xml:lang="de">foo</p>
-                                    </summary>
-                                    <msItem>
-                                        <textLang xml:lang="de"/>
-                                    </msItem>
-                                </msContents>
-                                <physDesc>
-                                    <objectDesc form='copy'>
-                                        <supportDesc>
-                                            <support>
-                                                <material type="paper"/>
-                                            </support>
-                                            <extent>
-                                                <dimensions type="leaves">
-                                                    <height unit="cm" quantity="36.0"/>
-                                                    <width unit="cm" quantity="23.5"/>
-                                                </dimensions>
-                                            </extent>
-                                        </supportDesc>
-                                    </objectDesc>
-                                </physDesc>
-                                <history>
-                                    <origin>
-                                        <origDate calendar="unknown" from-custom="1615-04-15" to-custom="1700-12-31"/>
-                                    </origin>
-                                </history>
-                            </msDesc>
-                        </sourceDesc>
-                    </fileDesc>
-                    <encodingDesc>
-                        <editorialDecl>
-                            <p>
-                                <ref target="https://www.ssrq-sds-fds.ch/wiki/Transkriptionsrichtlinien"/>
-                            </p>
-                        </editorialDecl>
-                    </encodingDesc>
-                    <profileDesc>
-                        <textClass>
-                            <keywords>
-                                <term ref="key000192"/>
-                                <term ref="key000097"/>
-                                <term ref="key000049"/>
-                                <term ref="key000193"/>
-                            </keywords>
-                        </textClass>
-                    </profileDesc>
-                </teiHeader>""",
+                        <fileDesc>
+                            <titleStmt>
+                                <title>foo</title>
+                                <editor>
+                                    <persName>Michael Nadig</persName>
+                                </editor>
+                                <respStmt>
+                                    <persName>Ariane Huber Hernández</persName>
+                                    <persName>Michael Nadig</persName>
+                                    <resp>Transkription</resp>
+                                </respStmt>
+                            </titleStmt>
+                            <publicationStmt>
+                                <publisher>SSRQ-SDS-FDS</publisher>
+                                <availability>
+                                    <licence target="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+                                        Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)
+                                    </licence>
+                                </availability>
+                            </publicationStmt>
+                            <seriesStmt>
+                                <title>Sammlung Schweizerischer Rechtsquellen</title>
+                                <respStmt>
+                                    <orgName>Rechtsquellenstiftung des Schweizerischen Juristenvereins</orgName>
+                                    <resp>Herausgabe</resp>
+                                </respStmt>
+                                <idno>SSRQ-FR-I_2_8-1-1</idno>
+                                <idno type="uuid">ad28656b-5c8d-459c-afb4-3e6ddf70810d</idno>
+                            </seriesStmt>
+                            <sourceDesc>
+                                <msDesc>
+                                    <msIdentifier>
+                                        <idno xml:lang="de" source="http://foo.bar">bar</idno>
+                                        <repository xml:lang="de">foo</repository>
+                                    </msIdentifier>
+                                    <head>Projekt eines Eides für den Förster oder Bannwart in Sax-Forstegg</head>
+                                    <msContents>
+                                        <summary>
+                                            <p xml:lang="de">foo</p>
+                                        </summary>
+                                        <msItem>
+                                            <textLang xml:lang="de"/>
+                                        </msItem>
+                                    </msContents>
+                                    <physDesc>
+                                        <objectDesc form='copy'>
+                                            <supportDesc>
+                                                <support>
+                                                    <material type="paper"/>
+                                                </support>
+                                                <extent>
+                                                    <dimensions type="leaves">
+                                                        <height unit="cm" quantity="36.0"/>
+                                                        <width unit="cm" quantity="23.5"/>
+                                                    </dimensions>
+                                                </extent>
+                                            </supportDesc>
+                                        </objectDesc>
+                                    </physDesc>
+                                    <history>
+                                        <origin>
+                                            <origDate calendar="unknown" from-custom="1615-04-15" to-custom="1700-12-31"/>
+                                        </origin>
+                                    </history>
+                                </msDesc>
+                            </sourceDesc>
+                        </fileDesc>
+                        <encodingDesc>
+                            <editorialDecl>
+                                <p>
+                                    <ref target="https://www.ssrq-sds-fds.ch/wiki/Transkriptionsrichtlinien"/>
+                                </p>
+                            </editorialDecl>
+                        </encodingDesc>
+                        <profileDesc>
+                            <textClass>
+                                <keywords>
+                                    <term ref="key000192"/>
+                                    <term ref="key000097"/>
+                                    <term ref="key000049"/>
+                                    <term ref="key000193"/>
+                                </keywords>
+                            </textClass>
+                        </profileDesc>
+                    </teiHeader>""",
             True,
         ),
         (
             "invalid-teiHeader-without-fileDesc",
             """<teiHeader>
-                    <encodingDesc>
-                        <editorialDecl>
-                            <p>
-                                <ref target="https://www.ssrq-sds-fds.ch/wiki/Transkriptionsrichtlinien"/>
-                            </p>
-                        </editorialDecl>
-                    </encodingDesc>
-                    <profileDesc>
-                        <textClass>
-                            <keywords>
-                                <term ref="key000192"/>
-                                <term ref="key000097"/>
-                                <term ref="key000049"/>
-                                <term ref="key000193"/>
-                            </keywords>
-                        </textClass>
-                    </profileDesc>
-                </teiHeader>""",
+                        <encodingDesc>
+                            <editorialDecl>
+                                <p>
+                                    <ref target="https://www.ssrq-sds-fds.ch/wiki/Transkriptionsrichtlinien"/>
+                                </p>
+                            </editorialDecl>
+                        </encodingDesc>
+                        <profileDesc>
+                            <textClass>
+                                <keywords>
+                                    <term ref="key000192"/>
+                                    <term ref="key000097"/>
+                                    <term ref="key000049"/>
+                                    <term ref="key000193"/>
+                                </keywords>
+                            </textClass>
+                        </profileDesc>
+                    </teiHeader>""",
             False,
         ),
     ],


### PR DESCRIPTION
# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

We are only using one `<seriesStmt/>` – so it is a bit messy to use an attribute `@xml:id` here.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [x] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
