### PR TITLE
[ci]: only publish docs after push on dev

### DIFF
--- a/.github/workflows/pr_to_dev.yml
+++ b/.github/workflows/pr_to_dev.yml
@@ -7,6 +7,10 @@ on:
     branches: ['dev']
   workflow_dispatch:
 
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -32,6 +36,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     needs: test
     permissions:
       contents: write


### PR DESCRIPTION
# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

Just a small tweak on the CI-workflow for PRs / pushes on `dev`. PRs should now no longer trigger a deployment of the docs-page.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [x] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
