### PR TITLE
schema corrections and additions

### DIFF
--- a/src/schema/commons/classes.odd.xml
+++ b/src/schema/commons/classes.odd.xml
@@ -503,9 +503,9 @@
     <classSpec ident="att.global.responsibility" type="atts" mode="change">
       <attList>
         <attDef ident="cert" mode="replace">
-          <desc xml:lang="de" versionDate="2023-04-11">Angabe des Grads der Sicherheit</desc>
+          <desc xml:lang="de" versionDate="2023-04-11">Angabe des Grads der Sicherheit; nur notwendig bei unsicherer Angabe</desc>
           <desc xml:lang="en" versionDate="2023-04-11">Indication of the degree of certainty</desc>
-          <desc xml:lang="fr" versionDate="2023-04-11">Indication du degré de certitude</desc>
+          <desc xml:lang="fr" versionDate="2023-04-11">Indication du degré de certitude ; nécessaire uniquement en cas d'indication incertaine</desc>
           <desc xml:lang="it" versionDate="2023-05-17">Indicazione del grado di certezza</desc>
           <valList type="closed">
             <valItem ident="high">

--- a/src/schema/commons/classes.odd.xml
+++ b/src/schema/commons/classes.odd.xml
@@ -458,7 +458,7 @@
               <desc xml:lang="it" versionDate="2023-06-30">Latino</desc>
             </valItem>
             <valItem ident="rm">
-              <desc xml:lang="de" versionDate="2023-06-30">Rätoromanisch</desc>
+              <desc xml:lang="de" versionDate="2023-09-01">Rätoromanisch</desc>
               <desc xml:lang="en" versionDate="2023-06-30">Romansh</desc>
               <desc xml:lang="fr" versionDate="2023-06-30">Romanche</desc>
               <desc xml:lang="it" versionDate="2023-06-30">Romancio</desc>
@@ -503,10 +503,10 @@
     <classSpec ident="att.global.responsibility" type="atts" mode="change">
       <attList>
         <attDef ident="cert" mode="replace">
-          <desc xml:lang="de" versionDate="2023-04-11">Angabe des Grads der Sicherheit; nur notwendig bei unsicherer Angabe</desc>
-          <desc xml:lang="en" versionDate="2023-04-11">Indication of the degree of certainty</desc>
-          <desc xml:lang="fr" versionDate="2023-04-11">Indication du degré de certitude ; nécessaire uniquement en cas d'indication incertaine</desc>
-          <desc xml:lang="it" versionDate="2023-05-17">Indicazione del grado di certezza</desc>
+          <desc xml:lang="de" versionDate="2023-09-01">Angabe des Grads der Sicherheit; nur notwendig bei unsicherer Angabe</desc>
+          <desc xml:lang="en" versionDate="2023-09-01">Indication of the degree of certainty; only necessary if the information is uncertain</desc>
+          <desc xml:lang="fr" versionDate="2023-09-01">Indication du degré de certitude ; nécessaire uniquement en cas d'indication incertaine</desc>
+          <desc xml:lang="it" versionDate="2023-09-01">Indicazione del grado di certezza; necessario solo se l'informazione è incerta</desc>
           <valList type="closed">
             <valItem ident="high">
               <desc xml:lang="de" versionDate="2023-04-11">hoch</desc>

--- a/src/schema/commons/classes.odd.xml
+++ b/src/schema/commons/classes.odd.xml
@@ -458,7 +458,7 @@
               <desc xml:lang="it" versionDate="2023-06-30">Latino</desc>
             </valItem>
             <valItem ident="rm">
-              <desc xml:lang="de" versionDate="2023-06-30">Bündnerromanisch</desc>
+              <desc xml:lang="de" versionDate="2023-06-30">Rätoromanisch</desc>
               <desc xml:lang="en" versionDate="2023-06-30">Romansh</desc>
               <desc xml:lang="fr" versionDate="2023-06-30">Romanche</desc>
               <desc xml:lang="it" versionDate="2023-06-30">Romancio</desc>

--- a/src/schema/elements/author.xml
+++ b/src/schema/elements/author.xml
@@ -14,11 +14,18 @@
   <classes mode="replace">
     <memberOf key="att.naming"/>
     <memberOf key="model.respLike"/>
+    <memberOf key="att.global.responsibility"/>
   </classes>
   <content>
-    <alternate maxOccurs="unbounded">
-      <textNode/>
-      <elementRef key="persName"/>
+    <alternate>
+        <sequence preserveOrder="false" maxOccurs="unbounded">
+            <elementRef minOccurs="0" key="persName"/>
+            <textNode/>
+        </sequence>
+        <sequence preserveOrder="false" maxOccurs="unbounded">
+            <elementRef key="orgName"/>
+            <textNode/>
+        </sequence>
     </alternate>
   </content>
   <constraintSpec scheme="schematron" ident="sch-el-author">
@@ -52,6 +59,7 @@
         </valItem>
       </valList>
     </attDef>
+    <attDef ident="resp" mode="delete"/>
   </attList>
   <exemplum xml:lang="de" type="ssrq-doc-example" versionDate="2023-05-05">
     <p>Angabe des Schreibers eines Stücks mit Erfassung des Personennamens</p>

--- a/src/schema/elements/author.xml
+++ b/src/schema/elements/author.xml
@@ -18,14 +18,14 @@
   </classes>
   <content>
     <alternate>
-        <sequence preserveOrder="false" maxOccurs="unbounded">
-            <elementRef minOccurs="0" key="persName"/>
-            <textNode/>
-        </sequence>
-        <sequence preserveOrder="false" maxOccurs="unbounded">
-            <elementRef key="orgName"/>
-            <textNode/>
-        </sequence>
+      <sequence preserveOrder="false" maxOccurs="unbounded">
+        <elementRef minOccurs="0" key="persName"/>
+        <textNode/>
+      </sequence>
+      <sequence preserveOrder="false" maxOccurs="unbounded">
+        <elementRef key="orgName"/>
+        <textNode/>
+      </sequence>
     </alternate>
   </content>
   <constraintSpec scheme="schematron" ident="sch-el-author">

--- a/src/schema/elements/author.xml
+++ b/src/schema/elements/author.xml
@@ -12,9 +12,9 @@
   <desc xml:lang="it" versionDate="2023-08-17">Contiene l'autore di una fonte come parte di <gi>msItem</gi>.
     </desc>
   <classes mode="replace">
+    <memberOf key="att.global.responsibility"/>
     <memberOf key="att.naming"/>
     <memberOf key="model.respLike"/>
-    <memberOf key="att.global.responsibility"/>
   </classes>
   <content>
     <alternate>

--- a/src/schema/elements/gap.xml
+++ b/src/schema/elements/gap.xml
@@ -105,6 +105,10 @@
   <xi:include href="examples.xml" xpointer="ex-gap-line-en"/>
   <xi:include href="examples.xml" xpointer="ex-gap-line-fr"/>
   <xi:include href="examples.xml" xpointer="ex-gap-line-it"/>
+  <xi:include href="examples.xml" xpointer="ex-gap-missing-de"/>
+  <xi:include href="examples.xml" xpointer="ex-gap-missing-en"/>
+  <xi:include href="examples.xml" xpointer="ex-gap-missing-fr"/>
+  <xi:include href="examples.xml" xpointer="ex-gap-missing-it"/>
   <xi:include href="examples.xml" xpointer="ex-gap-source-de"/>
   <xi:include href="examples.xml" xpointer="ex-gap-source-en"/>
   <xi:include href="examples.xml" xpointer="ex-gap-source-fr"/>

--- a/src/schema/elements/origDate.xml
+++ b/src/schema/elements/origDate.xml
@@ -39,27 +39,27 @@
   <xi:include href="examples.xml" xpointer="ex-origDate-abbr-fr"/>
   <xi:include href="examples.xml" xpointer="ex-origDate-abbr-it"/>
   <remarks xml:lang="de" versionDate="2023-08-23">
-    <p>Mit <att>when-custom</att> und <att>calendar</att> wird das Datum gemäss den Datierungsrichtlinien
+    <p>Mit <att>when-custom</att> und <att>calendar</att> wird das Datum gemäss den <ref target="dating_guidelines.md">Datierungsrichtlinien</ref>
       erfasst. <gi>origDate</gi> wird nur im Kopfbereich für das
       normalisierte Originaldatum eines Dokuments verwendet. Es handelt es sich um die Datierung des Dokuments (Herstellungsdatum) und nicht um die Datierung des Inhalts des Dokuments. Im Textbereich,
         den Kommentaren und Anmerkungen wird <gi>date</gi> verwendet.  Zum Umgang mit Heiligenfesten und anderen kirchlichen Feiertagen vgl. <gi>date</gi>. </p>
   </remarks>
   <remarks xml:lang="en" versionDate="2023-08-22">
     <p>With <att>when-custom</att> and
-      <att>calendar</att> the date is recorded according to the dating guidelines. <gi>origDate</gi> is only used in the header for the normalized original date of a document. <gi>date</gi> is used in the text area, comments and annotations.
+      <att>calendar</att> the date is recorded according to the <ref target="dating_guidelines.md">dating guidelines</ref>. <gi>origDate</gi> is only used in the header for the normalized original date of a document. <gi>date</gi> is used in the text area, comments and annotations.
       For how to deal with holy days and
       other church holidays, see <gi>date</gi>. </p>
   </remarks>
   <remarks xml:lang="fr" versionDate="2023-08-22">
     <p>Avec <att>when-custom</att> et
-      <att>calendar</att> la date est enregistrée conformément aux directives de datation.  <gi>origDate</gi> n'est utilisé dans l'en-tête que pour la date
+      <att>calendar</att> la date est enregistrée conformément aux <ref target="dating_guidelines.md">directives de datation</ref>.  <gi>origDate</gi> n'est utilisé dans l'en-tête que pour la date
       d'origine normalisée d'un document.  <gi>date</gi> est utilisé dans la zone de
       texte, les commentaires et les annotations. Pour savoir comment gérer
       les jours saints et autres fêtes religieuses, consultez <gi>date</gi>.</p>
   </remarks>
   <remarks xml:lang="it" versionDate="2023-08-22">
     <p>Con <att>when-custom</att>
-      e <att>calendar</att> la data viene registrata secondo le linee guida per gli appuntamenti.  <gi>origDate</gi> viene utilizzato solo nell'intestazione
+      e <att>calendar</att> la data viene registrata secondo le linee <ref target="dating_guidelines.md">guida per gli appuntamenti</ref>.  <gi>origDate</gi> viene utilizzato solo nell'intestazione
       per la data originale normalizzata di un documento. La <gi>data</gi> viene utilizzata
       nell'area di testo, nei commenti e nelle annotazioni. Per sapere come
       gestire i giorni sacri e le altre festività religiose, vedi <gi>date</gi>.</p>

--- a/src/schema/examples/examples.xml
+++ b/src/schema/examples/examples.xml
@@ -995,6 +995,22 @@
       <p>Esempio di datazione e luogo di emissione di un documento</p>
       <xi:include href="history.xml"/>
     </exemplum>
+    <exemplum xml:lang="de" xml:id="ex-gap-missing-de">
+      <p>Beispiel eines fehlenden Textes, der in retrodigitalisierten Vorlage nicht vorhanden ist</p>
+      <xi:include href="gap.xml" xpointer="ex-gap-missing"/>
+    </exemplum>
+    <exemplum xml:lang="en" xml:id="ex-gap-missing-en">
+      <p>Example of missing text not present in retro-digitised template</p>
+      <xi:include href="gap.xml" xpointer="ex-gap-missing"/>
+    </exemplum>
+    <exemplum xml:lang="fr" xml:id="ex-gap-missing-fr">
+      <p>Exemple d'un texte manquant qui n'est pas présent dans le modèle rétro-numérisé</p>
+      <xi:include href="gap.xml" xpointer="ex-gap-missing"/>
+    </exemplum>
+    <exemplum xml:lang="it" xml:id="ex-gap-missing-it">
+      <p>Esempio di testo mancante che non è presente nel modello retrodigitalizzato</p>
+      <xi:include href="gap.xml" xpointer="ex-gap-missing"/>
+    </exemplum>
     <exemplum xml:lang="de" xml:id="ex-gap-line-de">
       <p>Unlesbare Zeile ohne Streichung oder Beschädigung</p>
       <xi:include href="gap.xml" xpointer="ex-gap-line"/>

--- a/src/schema/examples/gap.xml
+++ b/src/schema/examples/gap.xml
@@ -7,4 +7,11 @@
     <gap source="urn:ssrq:SSRQ-SG-III_4-143-1"/>
     <note>Inhaltlich gleich.</note>
   </egXML>
+  <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="ex-gap-missing">
+    <gap reason="missing"/>
+    <note>Pas de transcription par Favarger 1982. Note
+            Favarger 1982 : Cf. <ref>SDS_NE_1_47</ref> du
+            17 août 1508 qui accorde la même franchise aux francs habergeants
+            de la Sagne.</note>
+  </egXML>
 </div>

--- a/tests/src/schema/elements/test_author.py
+++ b/tests/src/schema/elements/test_author.py
@@ -12,17 +12,22 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
     [
         (
             "valid-author-with-persName",
-            "<author role='scribe'><persName ref='per002336'>Adam Böniger</persName>, Landschreiber von Glarus</author>",
+            "<author role='scribe'><persName ref='per002336'>Adam Böniger</persName></author>",
             True,
         ),
         (
-            "valid-author-without-persName",
-            "<author role='scribe'>Adam Böniger, Landschreiber von Glarus</author>",
+            "valid-author-with-multiple-persName",
+            "<author role='scribe'><persName ref='per002336'>Adam Böniger</persName> <persName>Hans Müller</persName></author>",
             True,
+        ),
+        (
+            "invalid-author-with-persName-orgName",
+            "<author role='scribe'><persName ref='per002336'>Adam Böniger</persName> <orgName>Staatskanzlei</orgName></author>",
+            False,
         ),
         (
             "invalid-author-with-key",
-            "<author role='scribe' key='bar'>Adam Böniger, Landschreiber von Glarus</author>",
+            "<author role='scribe' key='bar'><persName ref='per002336'>Adam Böniger</persName></author>",
             False,
         ),
         (


### PR DESCRIPTION
- [fix]: german value for 'rm'
- [fix]: content model for tei:author
- [fix]: missing link to dating guidelines
- [docs]: more examples for tei:gap
