### PR TITLE
[fix]: regex for ssrq.date.point

### DIFF
--- a/src/schema/commons/patterns.odd.xml
+++ b/src/schema/commons/patterns.odd.xml
@@ -11,7 +11,7 @@
       <desc xml:lang="en" versionDate="2023-05-05">SLS defined pattern for time points - based on days</desc>
       <desc xml:lang="fr" versionDate="2023-05-05">SDS modèle défini pour l'heure - basé sur les jours</desc>
       <content>
-        <dataRef name="string" restriction="(\d{4}|-)-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1])"/>
+        <dataRef name="string" restriction="(((\d{4}|-)-(0[1-9]|1[0-2]))|--)-([0-2][0-9]|3[0-1])"/>
       </content>
     </dataSpec>
     <dataSpec ident="ssrq.time.point" mode="add" module="ssrq.core.module">

--- a/tests/src/schema/elements/test_date.py
+++ b/tests/src/schema/elements/test_date.py
@@ -21,6 +21,11 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
             True,
         ),
         (
+            "date-with-valid-when-without-year-and-month",
+            "<date when-custom='---12' calendar='gregorian'>Immer am 12.</date>",
+            True,
+        ),
+        (
             "date-with-invalid-when-month-too-large",
             "<date when-custom='1756-92-12' calendar='gregorian'>12. Februar 1756</date>",
             False,
@@ -28,6 +33,11 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
         (
             "date-with-invalid-when-year-only",
             "<date when-custom='1756' calendar='gregorian'>1756</date>",
+            False,
+        ),
+        (
+            "date-with-invalid-when-month-only",
+            "<date when-custom='--09' calendar='gregorian'>September</date>",
             False,
         ),
         (


### PR DESCRIPTION
This patch allows to abbreviate year and month.
