### PR TITLE
feat: changed content model of tei:idno

### DIFF
--- a/src/schema/commons/constraints.odd.xml
+++ b/src/schema/commons/constraints.odd.xml
@@ -43,7 +43,7 @@
       <desc xml:lang="en" versionDate="2023-05-23">Global constraint to ensure the usage of text</desc>
       <constraint>
         <sch:pattern>
-          <sch:rule context="tei:*[name() = ('ab', 'abbr', 'add', 'bibl', 'custEvent', 'del', 'div', 'expan', 'foreign', 'fw', 'head', 'hi', 'item', 'label', 'lem', 'licence', 'note', 'num', 'orgName', 'orig', 'p', 'persName', 'placeName', 'publisher', 'pubPlace', 'q', 'quote', 'repository', 'seg', 'settlement', 'signed', 'supplied', 'time', 'title', 'unclear')][not(*)]">
+          <sch:rule context="tei:*[name() = ('ab', 'abbr', 'add', 'bibl', 'custEvent', 'del', 'div', 'expan', 'foreign', 'fw', 'head', 'hi', 'idno', 'item', 'label', 'lem', 'licence', 'note', 'num', 'orgName', 'orig', 'p', 'persName', 'placeName', 'publisher', 'pubPlace', 'q', 'quote', 'repository', 'seg', 'settlement', 'signed', 'supplied', 'time', 'title', 'unclear')][not(*)]">
             <sch:assert test="string-length(normalize-space(.)) &gt; 0"><sch:name/>
                             must not be empty.
                         </sch:assert>

--- a/src/schema/elements/idno.xml
+++ b/src/schema/elements/idno.xml
@@ -24,7 +24,7 @@
     <memberOf key="ssrq.att.source"/>
   </classes>
   <content>
-    <dataRef name="string" restriction="\S+.*"/>
+    <textNode/>
   </content>
   <constraintSpec scheme="schematron" ident="sch-el-idno">
     <desc xml:lang="en" versionDate="2023-09-26">Constraints for tei:idno</desc>

--- a/tests/src/schema/elements/test_idno.py
+++ b/tests/src/schema/elements/test_idno.py
@@ -22,16 +22,6 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
             False,
         ),
         (
-            "invalid-idno-with-whitespace-only",
-            "<idno> </idno>",
-            False,
-        ),
-        (
-            "invalid-empty-idno",
-            "<idno/>",
-            False,
-        ),
-        (
             "idno-archive-invalid",
             " <idno xml:lang='de' source='foo.bar'>foo</idno>",
             False,

--- a/tests/src/schema/test_constraints.py
+++ b/tests/src/schema/test_constraints.py
@@ -174,6 +174,16 @@ def test_datable_custom_attr(
             "<head/>",
             False,
         ),
+        (
+            "invalid-idno-with-whitespace-only",
+            "<idno> </idno>",
+            False,
+        ),
+        (
+            "invalid-empty-idno",
+            "<idno/>",
+            False,
+        ),
     ],
 )
 def test_text_content_constraint_gl4(


### PR DESCRIPTION
This commit replaces a wrong regex with tei:textNode and adds tei:idno to the list of non-empty-elements.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [x] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
