### PR TITLE
Fix the usage of app and the corresponding wit and source attributes

### DIFF
--- a/src/schema/commons/classes.odd.xml
+++ b/src/schema/commons/classes.odd.xml
@@ -737,7 +737,11 @@
                         texte déclarés avec <gi>witness</gi> dans le <gi>teiHeader</gi>.
                     </desc>
           <datatype>
-            <dataRef name="IDREFS"/>
+            <rng:list>
+              <rng:oneOrMore>
+                <rng:ref name="ssrq.witness.pointer"/>
+              </rng:oneOrMore>
+            </rng:list>
           </datatype>
           <constraintSpec scheme="schematron" ident="sch-att-wit">
             <desc xml:lang="en" versionDate="2023-06-22">Make sure, the referenced ID belongs to a witness
@@ -746,17 +750,13 @@
             <constraint>
               <sch:pattern>
                 <sch:rule context="tei:*[@wit]">
-                  <sch:let name="wits" value="tokenize(@wit, ' ')"/>
+                  <sch:let name="wits" value="for $wit in tokenize(@wit, ' ') return replace($wit, '^(id-ssrq-[\w\d-]+)(#\d+)?$', '$1')"/>
                   <!--This rule is introduced, because @wit should not point to any other element
                                         type than a witness, and this: <anyElement xml:id="foo"/> <rdg wit="foo"/>
                                         would be valid XML.
                                     -->
                   <sch:assert test="every $wit in $wits satisfies id($wit)/name() = 'witness'" xml:lang="en">
                                         Every referenced ID in @wit must belong to a witness element.
-                                    </sch:assert>
-                  <!-- This rule is introduced, because <rdg wit="foo foo"/> would be valid XML. -->
-                  <sch:assert test="count($wits) = count(distinct-values($wits))" xml:lang="en">
-                                        Every ID may be referenced just once.
                                     </sch:assert>
                 </sch:rule>
               </sch:pattern>

--- a/src/schema/commons/classes.odd.xml
+++ b/src/schema/commons/classes.odd.xml
@@ -750,7 +750,7 @@
             <constraint>
               <sch:pattern>
                 <sch:rule context="tei:*[@wit]">
-                  <sch:let name="wits" value="for $wit in tokenize(@wit, ' ') return replace($wit, '^(id-ssrq-[\w\d-]+)(#\d+)?$', '$1')"/>
+                  <sch:let name="wits" value="for $wit in tokenize(@wit, ' ') return replace($wit, '^(id-ssrq-[\w\d-]+)(#(\d+|fol\d+[rv]?|[pn]\d+))?$', '$1')"/>
                   <!--This rule is introduced, because @wit should not point to any other element
                                         type than a witness, and this: <anyElement xml:id="foo"/> <rdg wit="foo"/>
                                         would be valid XML.

--- a/src/schema/commons/patterns.odd.xml
+++ b/src/schema/commons/patterns.odd.xml
@@ -203,5 +203,33 @@
         </alternate>
       </content>
     </dataSpec>
+    <dataSpec ident="ssrq.witness.id" mode="add" module="ssrq.core.module">
+      <desc xml:lang="de" versionDate="2023-10-30">Definiert das Muster für die ID eines weiteren Textzeugens einer
+                Quelle.
+            </desc>
+      <desc xml:lang="en" versionDate="2023-10-30">Defines the pattern for the ID of another witness of a source.
+            </desc>
+      <desc xml:lang="fr" versionDate="2023-10-30">Définit le modèle pour l'ID d'un autre témoin d'une source.
+            </desc>
+      <content>
+        <!--
+            This restriction has two parts
+                1) A prefix "id-ssrq-". This prefix is used to make sure, that the xml:id is a valid token of
+                the XS:ID datatype (id est a NCName without colons). This is necessary, because the following
+                UUID may start with a letter, which is forbidden as first char in NCNames.
+                2) A UUID Version 4. This is used, because UUIDs are (potentially) persistant and globally
+                unique. This allows publishing the XML-files while still work in progress.
+        -->
+        <dataRef name="ID" restriction="id-ssrq-[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}"/>
+      </content>
+    </dataSpec>
+    <dataSpec ident="ssrq.witness.pointer" mode="add" module="ssrq.core.module">
+      <desc xml:lang="de" versionDate="2023-10-30">Definiert einen Pointer auf IDs vom Typ ssrq.witness.id, und erlaubt die Verwendung von Teilangaben über '#part'.</desc>
+      <desc xml:lang="en" versionDate="2023-10-30">Defines a pointer to IDs of type ssrq.witness.id, and allows the use of partial information via '#part'.</desc>
+      <desc xml:lang="fr" versionDate="2023-10-30">Définit un pointeur vers des ID de type ssrq.witness.id, et permet l'utilisation d'informations partielles via '#part'.</desc>
+      <content>
+        <dataRef name="string" restriction="id-ssrq-[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}(#\d+)?"/>
+      </content>
+    </dataSpec>
   </specGrp>
 </div>

--- a/src/schema/commons/patterns.odd.xml
+++ b/src/schema/commons/patterns.odd.xml
@@ -228,7 +228,7 @@
       <desc xml:lang="en" versionDate="2023-10-30">Defines a pointer to IDs of type ssrq.witness.id, and allows the use of partial information via '#part'.</desc>
       <desc xml:lang="fr" versionDate="2023-10-30">Définit un pointeur vers des ID de type ssrq.witness.id, et permet l'utilisation d'informations partielles via '#part'.</desc>
       <content>
-        <dataRef name="string" restriction="id-ssrq-[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}(#\d+)?"/>
+        <dataRef name="string" restriction="id-ssrq-[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}(#(\d+|fol\d+[rv]?|[pn]\d+))?"/>
       </content>
     </dataSpec>
   </specGrp>

--- a/src/schema/elements/app.xml
+++ b/src/schema/elements/app.xml
@@ -12,7 +12,12 @@
   <content>
     <sequence>
       <elementRef key="lem"/>
-      <elementRef key="rdg" maxOccurs="unbounded"/>
+      <sequence preserveOrder="false">
+        <alternate maxOccurs="unbounded">
+          <elementRef key="note"/>
+          <elementRef key="rdg"/>
+        </alternate>
+      </sequence>
     </sequence>
   </content>
   <attList>
@@ -21,9 +26,12 @@
     <attDef ident="to" mode="delete"/>
     <attDef ident="type" mode="delete"/>
   </attList>
-  <xi:include href="examples.xml" xpointer="ex-app-de"/>
-  <xi:include href="examples.xml" xpointer="ex-app-en"/>
-  <xi:include href="examples.xml" xpointer="ex-app-fr"/>
+  <xi:include href="examples.xml" xpointer="ex-app-rdg-de"/>
+  <xi:include href="examples.xml" xpointer="ex-app-rdg-en"/>
+  <xi:include href="examples.xml" xpointer="ex-app-rdg-fr"/>
+  <xi:include href="examples.xml" xpointer="ex-app-note-de"/>
+  <xi:include href="examples.xml" xpointer="ex-app-note-en"/>
+  <xi:include href="examples.xml" xpointer="ex-app-note-fr"/>
   <remarks xml:lang="de" versionDate="2023-08-18">
     <p>Ermöglicht verschiedene Lesarten eines Wortes oder eines Textabschnittes anzuzeigen unter Bezugnahme auf ein
             anderes Dokument oder mehrere andere Dokumente. Muss sich unmittelbar, ohne Leerschlag, an das Wort

--- a/src/schema/elements/bibl.xml
+++ b/src/schema/elements/bibl.xml
@@ -10,6 +10,7 @@
     </desc>
   <classes mode="replace">
     <memberOf key="model.biblLike"/>
+    <memberOf key="att.global"/>
   </classes>
   <content>
     <alternate maxOccurs="unbounded">
@@ -17,6 +18,15 @@
       <textNode/>
     </alternate>
   </content>
+  <attList>
+    <attDef ident="xml:id" mode="change">
+      <datatype>
+        <dataRef key="ssrq.witness.id"/>
+      </datatype>
+    </attDef>
+    <attDef ident="n" mode="delete"/>
+    <attDef ident="xml:lang" mode="delete"/>
+  </attList>
   <xi:include href="examples.xml" xpointer="ex-bibl-zot-de"/>
   <xi:include href="examples.xml" xpointer="ex-bibl-zot-en"/>
   <xi:include href="examples.xml" xpointer="ex-bibl-zot-fr"/>

--- a/src/schema/elements/lem.xml
+++ b/src/schema/elements/lem.xml
@@ -18,9 +18,9 @@
       <rng:ref name="ssrq.content.default"/>
     </rng:oneOrMore>
   </content>
-  <xi:include href="examples.xml" xpointer="ex-app-de"/>
-  <xi:include href="examples.xml" xpointer="ex-app-en"/>
-  <xi:include href="examples.xml" xpointer="ex-app-fr"/>
+  <xi:include href="examples.xml" xpointer="ex-app-rdg-de"/>
+  <xi:include href="examples.xml" xpointer="ex-app-rdg-en"/>
+  <xi:include href="examples.xml" xpointer="ex-app-rdg-fr"/>
   <remarks xml:lang="de" versionDate="2023-07-13">
     <p>Die abweichende Textvariante wird in <gi>rdg</gi> wiedergegeben.
         </p>

--- a/src/schema/elements/note.xml
+++ b/src/schema/elements/note.xml
@@ -2,15 +2,15 @@
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl"
         type="application/xml"
         schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" ident="note" module="core" mode="change">
-  <desc xml:lang="de" versionDate="2023-07-07">Enthält entweder eine sachkritische Anmerkung zu einer
-        Einzelstelle im Editionstext oder eine Anmerkung im Original.
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" ident="note" module="core" mode="change">
+  <desc xml:lang="de" versionDate="2023-10-30">Enthält entweder eine sachkritische Anmerkung zu einer
+        Einzelstelle im Editionstext, Anmerkung im Original oder den Verweis auf einen weiteren Textzeugen in dem der jeweilige Text wiederverwendet wird.
     </desc>
-  <desc xml:lang="en" versionDate="2023-07-07">Contains either a factual comment on a single passage in the text of
-        the edition or a comment in the original.
+  <desc xml:lang="en" versionDate="2023-10-30">Contains either a factual comment on a single passage of the text of
+        the edition, a comment in the original, or a reference to another textual witness in which the respective text is reused.
     </desc>
-  <desc xml:lang="fr" versionDate="2023-07-07">Contient soit un commentaire factuel sur un seul passage du texte de
-        l'édition, soit un commentaire dans l'original.
+  <desc xml:lang="fr" versionDate="2023-10-30">Contient soit un commentaire factuel sur un passage unique du texte
+        de l'édition, un commentaire dans l'original, soit une référence à un autre témoin textuel dans lequel le texte respectif est réutilisé.
     </desc>
   <classes mode="replace">
     <memberOf key="att.placement"/>
@@ -23,6 +23,34 @@
       <elementRef key="ref"/>
     </alternate>
   </content>
+  <constraintSpec scheme="schematron" ident="sch-el-note">
+    <desc xml:lang="en" versionDate="2023-10-30">Constraint for
+            <gi>note</gi>, to ensure the childs inside <gi>app</gi>.
+        </desc>
+    <constraint>
+      <sch:pattern>
+        <sch:rule context="tei:note[parent::tei:app]">
+          <sch:assert test="every $child in * satisfies $child/name() = ('ref', 'orig')">
+                        If a note is used inside a critical apparatus, only ref and orig are allowed as childs.
+                    </sch:assert>
+          <sch:assert test="count(*) = 2">
+                        A note inside a critical apparatus must have exactly two childs.
+                    </sch:assert>
+          <sch:assert test="string-length(normalize-space(text())) = 0">
+                        A note inside a critical apparatus must not have text content.
+                    </sch:assert>
+          <sch:assert test=".[@type]">
+                        A note inside a critical apparatus must have a type attribute.
+                    </sch:assert>
+        </sch:rule>
+        <sch:rule context="tei:note[@type = 'text_comparison']">
+          <sch:assert test="parent::tei:app">
+                        A note with type text_comparison must be inside a critical apparatus.
+                    </sch:assert>
+        </sch:rule>
+      </sch:pattern>
+    </constraint>
+  </constraintSpec>
   <attList>
     <attDef ident="type" mode="replace">
       <desc xml:lang="de" versionDate="2023-07-07">Art der Anmerkung; wird dieses Attribut nicht vergeben, dann
@@ -40,12 +68,20 @@
           <desc xml:lang="en" versionDate="2023-07-07">note in the original</desc>
           <desc xml:lang="fr" versionDate="2023-07-07">note dans l'original</desc>
         </valItem>
+        <valItem ident="text_comparison">
+          <desc xml:lang="de" versionDate="2023-10-30">Verweis auf parallele Textstelle</desc>
+          <desc xml:lang="en" versionDate="2023-10-30">reference to parallel passage</desc>
+          <desc xml:lang="fr" versionDate="2023-10-30">référence à un passage parallèle</desc>
+        </valItem>
       </valList>
     </attDef>
   </attList>
   <xi:include href="examples.xml" xpointer="ex-note-de"/>
   <xi:include href="examples.xml" xpointer="ex-note-en"/>
   <xi:include href="examples.xml" xpointer="ex-note-fr"/>
+  <xi:include href="examples.xml" xpointer="ex-app-note-de"/>
+  <xi:include href="examples.xml" xpointer="ex-app-note-en"/>
+  <xi:include href="examples.xml" xpointer="ex-app-note-fr"/>
   <remarks xml:lang="de" versionDate="2023-07-07">
     <p>Ein <gi>note</gi>-Element folgt unmittelbar auf das Bezugswort im Editionstext. Wird
             Originaltext zitiert, wird dieser mit <gi>orig</gi> ausgezeichnet.

--- a/src/schema/elements/note.xml
+++ b/src/schema/elements/note.xml
@@ -4,7 +4,7 @@
         schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" ident="note" module="core" mode="change">
   <desc xml:lang="de" versionDate="2023-10-30">Enthält entweder eine sachkritische Anmerkung zu einer
-        Einzelstelle im Editionstext, Anmerkung im Original oder den Verweis auf einen weiteren Textzeugen in dem der jeweilige Text wiederverwendet wird.
+        Einzelstelle im Editionstext, eine Anmerkung im Original oder den Verweis auf einen weiteren Textzeugen in dem der jeweilige Text wiederverwendet wird.
     </desc>
   <desc xml:lang="en" versionDate="2023-10-30">Contains either a factual comment on a single passage of the text of
         the edition, a comment in the original, or a reference to another textual witness in which the respective text is reused.
@@ -25,16 +25,17 @@
   </content>
   <constraintSpec scheme="schematron" ident="sch-el-note">
     <desc xml:lang="en" versionDate="2023-10-30">Constraint for
-            <gi>note</gi>, to ensure the childs inside <gi>app</gi>.
+            <gi>note</gi>, to ensure the children inside <gi>app</gi>.
         </desc>
     <constraint>
       <sch:pattern>
         <sch:rule context="tei:note[parent::tei:app]">
           <sch:assert test="every $child in * satisfies $child/name() = ('ref', 'orig')">
-                        If a note is used inside a critical apparatus, only ref and orig are allowed as childs.
+                        If a note is used inside a critical apparatus, only ref and orig are
+                        allowed as children.
                     </sch:assert>
           <sch:assert test="count(*) = 2">
-                        A note inside a critical apparatus must have exactly two childs.
+                        A note inside a critical apparatus must have exactly two children.
                     </sch:assert>
           <sch:assert test="string-length(normalize-space(text())) = 0">
                         A note inside a critical apparatus must not have text content.
@@ -45,7 +46,7 @@
         </sch:rule>
         <sch:rule context="tei:note[@type = 'text_comparison']">
           <sch:assert test="parent::tei:app">
-                        A note with type text_comparison must be inside a critical apparatus.
+                        A note with type "text_comparison" must be inside a critical apparatus.
                     </sch:assert>
         </sch:rule>
       </sch:pattern>

--- a/src/schema/elements/rdg.xml
+++ b/src/schema/elements/rdg.xml
@@ -14,9 +14,9 @@
       <rng:ref name="ssrq.content.default"/>
     </rng:oneOrMore>
   </content>
-  <xi:include href="examples.xml" xpointer="ex-app-de"/>
-  <xi:include href="examples.xml" xpointer="ex-app-en"/>
-  <xi:include href="examples.xml" xpointer="ex-app-fr"/>
+  <xi:include href="examples.xml" xpointer="ex-app-rdg-de"/>
+  <xi:include href="examples.xml" xpointer="ex-app-rdg-en"/>
+  <xi:include href="examples.xml" xpointer="ex-app-rdg-fr"/>
   <remarks xml:lang="de" versionDate="2023-08-18">
     <p>In <att>wit</att> wird auf den anderen Textzeugen, auf dem die Lesart basiert, verwiesen. Bei Auslassungen kann ein leeres <gi>rdg</gi> verwendet werden. Verweise auf Teilabschnitte können über ein <val>#</val> angehängt werden.
         </p>

--- a/src/schema/elements/rdg.xml
+++ b/src/schema/elements/rdg.xml
@@ -18,16 +18,16 @@
   <xi:include href="examples.xml" xpointer="ex-app-en"/>
   <xi:include href="examples.xml" xpointer="ex-app-fr"/>
   <remarks xml:lang="de" versionDate="2023-08-18">
-    <p>In <att>wit</att> wird auf den anderen Textzeugen, auf dem die Lesart basiert, verwiesen. Bei Auslassungen kann ein leeres <gi>rdg</gi> verwendet werden.
+    <p>In <att>wit</att> wird auf den anderen Textzeugen, auf dem die Lesart basiert, verwiesen. Bei Auslassungen kann ein leeres <gi>rdg</gi> verwendet werden. Verweise auf Teilabschnitte können über ein <val>#</val> angehängt werden.
         </p>
   </remarks>
   <remarks xml:lang="en" versionDate="2023-08-18">
     <p>In <att>wit</att>, reference is made to the other textual witness on which the reading is based. An
-            empty <gi>rdg</gi> can be used for omissions.
+            empty <gi>rdg</gi> can be used for omissions. References to subsections can be appended via a <val>#</val>.
         </p>
   </remarks>
   <remarks xml:lang="fr" versionDate="2023-08-18">
-    <p>Dans <att>wit</att>, il est fait référence à l'autre témoin textuel sur lequel la lecture est basée. Un <gi>rdg</gi> vide peut être utilisé pour les omissions.
+    <p>Dans <att>wit</att>, il est fait référence à l'autre témoin textuel sur lequel la lecture est basée. Un <gi>rdg</gi> vide peut être utilisé pour les omissions. Les références aux sous-sections peuvent être ajoutées via un <val>#</val>.
         </p>
   </remarks>
 </elementSpec>

--- a/src/schema/elements/supplied.xml
+++ b/src/schema/elements/supplied.xml
@@ -26,6 +26,12 @@
                         Must contain either a resp or a source attribute.
                     </sch:assert>
         </sch:rule>
+        <sch:rule context="tei:supplied[@source]">
+          <sch:let name="sources" value="for $source in tokenize(@source, ' ') return replace($source, '^(id-ssrq-[\w\d-]+)(#(\d+|fol\d+[rv]?|[pn]\d+))?$', '$1')"/>
+          <sch:assert test="every $source in $sources satisfies exists(id($source))" xml:lang="en">
+                        Every referenced ID in @source must belong to an element with the same ID.
+                    </sch:assert>
+        </sch:rule>
       </sch:pattern>
     </constraint>
   </constraintSpec>
@@ -33,7 +39,11 @@
     <attDef ident="cert" mode="delete"/>
     <attDef ident="source" mode="replace">
       <datatype>
-        <dataRef name="IDREFS"/>
+        <rng:list>
+          <rng:oneOrMore>
+            <rng:ref name="ssrq.witness.pointer"/>
+          </rng:oneOrMore>
+        </rng:list>
       </datatype>
     </attDef>
     <attDef ident="reason" mode="replace">

--- a/src/schema/elements/witness.xml
+++ b/src/schema/elements/witness.xml
@@ -20,14 +20,7 @@
     </attDef>
     <attDef ident="xml:id" mode="change" usage="req">
       <datatype>
-        <!--This restriction has two parts
-                    1) A prefix "id-ssrq-". This prefix is used to make sure, that the xml:id is a valid token of
-                    the XS:ID datatype (id est a NCName without colons). This is necessary, because the following
-                    UUID may start with a letter, which is forbidden as first char in NCNames.
-                    2) A UUID Version 4. This is used, because UUIDs are (potentially) persistant and globally
-                    unique. This allows publishing the XML-files while still work in progress.
-                -->
-        <dataRef name="ID" restriction="id-ssrq-[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}"/>
+        <dataRef key="ssrq.witness.id"/>
       </datatype>
     </attDef>
     <attDef ident="xml:lang" mode="delete"/>

--- a/src/schema/examples/app.xml
+++ b/src/schema/examples/app.xml
@@ -2,7 +2,7 @@
 <egXML xmlns="http://www.tei-c.org/ns/Examples">
   <app>
     <lem>lxxxvii</lem>
-    <rdg wit="id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810e">
+    <rdg wit="id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810e#3">
             quadringentesimo
         </rdg>
     <rdg wit="id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810f">lxxxiiii</rdg>

--- a/src/schema/examples/app.xml
+++ b/src/schema/examples/app.xml
@@ -1,10 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-  <app>
-    <lem>lxxxvii</lem>
-    <rdg wit="id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810e#3">
+<div xmlns="http://www.tei-c.org/ns/1.0">
+  <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="ex-app-rdg">
+    <app>
+      <lem>lxxxvii</lem>
+      <rdg wit="id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810e#3">
             quadringentesimo
         </rdg>
-    <rdg wit="id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810f">lxxxiiii</rdg>
-  </app>
-</egXML>
+      <rdg wit="id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810f">lxxxiiii</rdg>
+    </app>
+  </egXML>
+  <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="ex-app-note">
+    <app>
+      <lem>graffschafft und gericht fuͤren oder ob man <lb/>jemant da fachen
+                und usser miner herren <term ref="lem003769.02">biet</term> fuͤren
+                welte</lem>
+      <rdg wit="SSRQ-SG-III_4-129-1, Art. 2">ampt unnd <lb/>gepiet
+                fachen oder füerenn</rdg>
+      <note type="text_comparison">
+        <ref target="urn:ssrq:SSRQ-SG-III_4-129-1">SSRQ-SG-III_4-129-1, Art. 2</ref>
+        <orig>ampt unnd <lb/>gepiet
+                    fachen oder füerenn</orig>
+      </note>
+    </app>
+  </egXML>
+</div>

--- a/src/schema/examples/examples.xml
+++ b/src/schema/examples/examples.xml
@@ -125,17 +125,29 @@
       <p>Exemple d'un ajout plus important</p>
       <xi:include href="addSpan.xml"/>
     </exemplum>
-    <exemplum xml:lang="de" xml:id="ex-app-de">
+    <exemplum xml:lang="de" xml:id="ex-app-note-de">
+      <p>Beispiel für einen Apparat mit Textvergleich</p>
+      <xi:include href="app.xml" xpointer="ex-app-note"/>
+    </exemplum>
+    <exemplum xml:lang="en" xml:id="ex-app-note-en">
+      <p>Example of an apparatus with text comparison</p>
+      <xi:include href="app.xml" xpointer="ex-app-note"/>
+    </exemplum>
+    <exemplum xml:lang="fr" xml:id="ex-app-note-fr">
+      <p>Exemple d'un appareil avec comparaison de texte</p>
+      <xi:include href="app.xml" xpointer="ex-app-note"/>
+    </exemplum>
+    <exemplum xml:lang="de" xml:id="ex-app-rdg-de">
       <p>Beispiel für einen Apparateintrag</p>
-      <xi:include href="app.xml"/>
+      <xi:include href="app.xml" xpointer="ex-app-rdg"/>
     </exemplum>
-    <exemplum xml:lang="en" xml:id="ex-app-en">
+    <exemplum xml:lang="en" xml:id="ex-app-rdg-en">
       <p>Example of an apparatus entry</p>
-      <xi:include href="app.xml"/>
+      <xi:include href="app.xml" xpointer="ex-app-rdg"/>
     </exemplum>
-    <exemplum xml:lang="fr" xml:id="ex-app-fr">
+    <exemplum xml:lang="fr" xml:id="ex-app-rdg-fr">
       <p>Exemple d'entrée d'appareil</p>
-      <xi:include href="app.xml"/>
+      <xi:include href="app.xml" xpointer="ex-app-rdg"/>
     </exemplum>
     <exemplum xml:lang="de" xml:id="ex-author-de">
       <p>Beispiel für die Angabe des Autors eines Stücks</p>

--- a/tests/src/schema/elements/test_app.py
+++ b/tests/src/schema/elements/test_app.py
@@ -4,58 +4,52 @@ from ..conftest import RNG_test_function
 
 
 @pytest.mark.parametrize(
-    "name, markup, result, message",
+    "name, markup, result",
     [
         (
             "valid-app",
             """<app>
-                        <lem>lxxxvij</lem>
-                        <rdg wit='ad28656b-5c8d-459c-afb4-3e6ddf70810d ad28656b-5c8d-459c-afb4-3e6ddf70810e'>quadringentesimo</rdg>
-                    </app>""",
-            False,
-            "without matching ID",
+                    <lem>lxxxvij</lem>
+                    <rdg wit='id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810e'>quadringentesimo</rdg>
+                </app>""",
+            True,
         ),
         (
             "valid-app-with-multiple-readings",
             """<app>
-                                                    <lem>lxxxvij</lem>
-                                                    <rdg wit="ad28656b-5c8d-459c-afb4-3e6ddf70810d ad28656b-5c8d-459c-afb4-3e6ddf70810e">quadringentesimo</rdg>
-                                                    <rdg wit="ad28656b-5c8d-459c-afb4-3e6ddf70810f">lxxxiiij</rdg>
-                                                </app>""",
-            False,
-            "without matching ID",
+                    <lem>lxxxvij</lem>
+                    <rdg wit="id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d">quadringentesimo</rdg>
+                    <rdg wit="id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810f">lxxxiiij</rdg>
+                </app>""",
+            True,
         ),
         (
             "invalid-app-without-lem",
             """<app>
-                                                    <rdg wit="ad28656b-5c8d-459c-afb4-3e6ddf70810d ad28656b-5c8d-459c-afb4-3e6ddf70810e">quadringentesimo</rdg>
-                                                </app>""",
+                    <rdg wit="id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d">quadringentesimo</rdg>
+                </app>""",
             False,
-            "without matching ID",
         ),
         (
             "invalid-app-without-rdg",
             "<app><lem>lxxxvij</lem></app>",
             False,
-            None,
         ),
         (
             "invalid-app-wrong-sequence",
             """<app>
-                                                    <rdg wit="ad28656b-5c8d-459c-afb4-3e6ddf70810d ad28656b-5c8d-459c-afb4-3e6ddf70810e">quadringentesimo</rdg>
-                                                    <lem>lxxxvij</lem>
-                                                </app>""",
+                    <rdg wit="id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d">quadringentesimo</rdg>
+                    <lem>lxxxvij</lem>
+                </app>""",
             False,
-            "without matching ID",
         ),
         (
             "invalid-app-with-attributes",
             """<app type='foo'>
-                                                    <lem>lxxxvij</lem>
-                                                    <rdg wit="ad28656b-5c8d-459c-afb4-3e6ddf70810d ad28656b-5c8d-459c-afb4-3e6ddf70810e">quadringentesimo</rdg>
-                                                </app>""",
+                    <lem>lxxxvij</lem>
+                    <rdg wit="id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d">quadringentesimo</rdg>
+                </app>""",
             False,
-            "without matching ID",
         ),
     ],
 )
@@ -64,14 +58,5 @@ def test_app(
     name: str,
     markup: str,
     result: bool,
-    message: str | None,
 ):
-    test_element_with_rng("app", name, markup, result, True)
-    if message:
-        validation_result = test_element_with_rng("app", name, markup, result, True)
-        file_reports = validation_result.reports[0]
-        assert isinstance(file_reports.report, list)
-        messages = "".join([error.message for error in file_reports.report])
-        assert message in messages
-    else:
-        test_element_with_rng("app", name, markup, result, False)
+    test_element_with_rng("app", name, markup, result, False)

--- a/tests/src/schema/elements/test_damage.py
+++ b/tests/src/schema/elements/test_damage.py
@@ -4,43 +4,37 @@ from ..conftest import RNG_test_function
 
 
 @pytest.mark.parametrize(
-    "name, markup, result, message",
+    "name, markup, result",
     [
         (
             "valid-damage-with-add",
             "<damage agent='water'><add hand='otherHand' place='overwritten'>zuͦ trincken</add></damage>",
             True,
-            None,
         ),
         (
             "valid-damage-with-gap",
             "<damage agent='faded_ink clipping'><gap quantity='9' unit='cm'/></damage>",
             True,
-            None,
         ),
         (
             "valid-damage-with-supplied",
-            "<damage agent='water'><supplied source='73988c1a-40e1-4527-94b7-736d418b29d0'>verthruwen</supplied></damage>",
-            False,
-            "without matching ID",
+            "<damage agent='water'><supplied source='id-ssrq-73988c1a-40e1-4527-94b7-736d418b29d0'>verthruwen</supplied></damage>",
+            True,
         ),
         (
             "valid-damage-with-unclear",
             "<damage agent='ink_blot'><unclear>die</unclear></damage>",
             True,
-            None,
         ),
         (
             "invalid-damage-without-agent",
             "<damage><unclear>die</unclear></damage>",
             False,
-            None,
         ),
         (
             "invalid-damage-with-wrong-attribute",
             "<damage agent='ink_blot' type='foo'><unclear>die</unclear></damage>",
             False,
-            None,
         ),
     ],
 )
@@ -49,14 +43,5 @@ def test_damage(
     name: str,
     markup: str,
     result: bool,
-    message: str | None,
 ):
-    test_element_with_rng("damage", name, markup, result, True)
-    if message:
-        validation_result = test_element_with_rng("damage", name, markup, result, True)
-        file_reports = validation_result.reports[0]
-        assert isinstance(file_reports.report, list)
-        messages = "".join([error.message for error in file_reports.report])
-        assert message in messages
-    else:
-        test_element_with_rng("damage", name, markup, result, False)
+    test_element_with_rng("damage", name, markup, result, False)

--- a/tests/src/schema/elements/test_rdg.py
+++ b/tests/src/schema/elements/test_rdg.py
@@ -12,7 +12,7 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
     [
         (
             "valid-rdg",
-            "<rdg wit='id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810e'>bar</rdg>",
+            "<rdg wit='id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810e#fol30r'>bar</rdg>",
             True,
         ),
         (
@@ -49,7 +49,7 @@ def test_rdg(
             """<TEI>
                 <witness xml:id='id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d'/>
                 <witness xml:id='id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810e'/>
-                <rdg wit='id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810e#3'>bar</rdg>
+                <rdg wit='id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810e#fol30r'>bar</rdg>
             </TEI>""",
             True,
         ),

--- a/tests/src/schema/elements/test_supplied.py
+++ b/tests/src/schema/elements/test_supplied.py
@@ -8,43 +8,37 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
 
 
 @pytest.mark.parametrize(
-    "name, markup, result, message",
+    "name, markup, result",
     [
         (
             "valid-supplied-source",
-            "<supplied source='73988c1a-40e1-4527-94b7-736d418b29d0'>foo</supplied>",
-            False,
-            "without matching ID",
+            "<supplied source='id-ssrq-ad28656b-5c8d-459c-afb4-3e6ddf70810d'>foo</supplied>",
+            True,
         ),
         (
             "invalid-supplied-source",
             "<supplied source='bar'>foo</supplied>",
             False,
-            None,
         ),
         (
             "supplied-valid-with-reason",
             "<supplied reason='omitted'>foo</supplied>",
             True,
-            None,
         ),
         (
             "supplied-valid-with-resp",
             "<supplied resp='CS'>foo</supplied>",
             True,
-            None,
         ),
         (
             "supplied-valid-with-multiple-attributes",
             "<supplied resp='CS' reason='omitted'>foo</supplied>",
             True,
-            None,
         ),
         (
             "supplied-with-invalid-attribute",
             "<supplied cert='bar'>foo</supplied>",
             False,
-            None,
         ),
     ],
 )
@@ -53,42 +47,43 @@ def test_supplied(
     name: str,
     markup: str,
     result: bool,
-    message: str | None,
 ):
-    test_element_with_rng("supplied", name, markup, result, True)
-    if message:
-        validation_result = test_element_with_rng(
-            "supplied", name, markup, result, True
-        )
-        file_reports = validation_result.reports[0]
-        assert isinstance(file_reports.report, list)
-        messages = "".join([error.message for error in file_reports.report])
-        assert message in messages
-    else:
-        test_element_with_rng("supplied", name, markup, result, False)
+    test_element_with_rng("supplied", name, markup, result, False)
 
 
 @pytest.mark.parametrize(
     "name, markup, result",
     [
         (
-            "invalid-empty-supplied-source",
-            "<supplied source='73988c1a-40e1-4527-94b7-736d418b29d0'/>",
-            False,
-        ),
-        (
-            "valid-supplied-source",
-            "<supplied source='73988c1a-40e1-4527-94b7-736d418b29d0'>foo</supplied>",
+            "valid-supplied-source-with-ref-to-bibl",
+            """
+            <TEI>
+                <bibl xml:id='id-ssrq73988c1a-40e1-4527-94b7-736d418b29d0'>foo</bibl>
+                <supplied source='id-ssrq73988c1a-40e1-4527-94b7-736d418b29d0'>foo</supplied>
+            </TEI>""",
             True,
         ),
         (
-            "invalid-supplied-source",
+            "invalid-empty-supplied-source-with-ref-to-bibl",
+            """
+            <TEI>
+                <bibl xml:id='id-ssrq73988c1a-40e1-4527-94b7-736d418b29d0'>foo</bibl>
+                <supplied source='id-ssrq73988c1a-40e1-4527-94b7-736d418b29d0'/>
+            </TEI>""",
+            False,
+        ),
+        (
+            "invalid-supplied-without-attribute",
             "<supplied>foo</supplied>",
             False,
         ),
         (
-            "invalid-supplied-conflicting-attributes",
-            "<supplied source='73988c1a-40e1-4527-94b7-736d418b29d0' resp='foo'>bar</supplied>",
+            "invalid-supplied-with-conflicting-attributes",
+            """
+            <TEI>
+                <bibl xml:id='id-ssrq73988c1a-40e1-4527-94b7-736d418b29d0'>foo</bibl>
+                <supplied resp='foo' source='id-ssrq73988c1a-40e1-4527-94b7-736d418b29d0'>foo</supplied>
+            </TEI>""",
             False,
         ),
     ],


### PR DESCRIPTION
- feat: changed datatypes of witness-ids + wit-attr
- docs: adopted examples and docs for new wit-datatype
- feat: extend ssrq.witness.pointer
- feat: use ssrq.witness.pointer for source in supplied
- feat: allow note inside app for text comparison

See the commits details for more infos.
