### PR TITLE
[feat]: extend content model for tei:quote

### DIFF
--- a/src/schema/elements/quote.xml
+++ b/src/schema/elements/quote.xml
@@ -12,9 +12,17 @@
     <memberOf key="ssrq.att.source"/>
   </classes>
   <content>
-    <rng:oneOrMore>
-      <rng:ref name="ssrq.content.default"/>
-    </rng:oneOrMore>
+    <rng:choice>
+      <rng:group>
+        <rng:ref name="seg"/>
+        <rng:oneOrMore>
+          <rng:ref name="seg"/>
+        </rng:oneOrMore>
+      </rng:group>
+      <rng:oneOrMore>
+        <rng:ref name="ssrq.content.default"/>
+      </rng:oneOrMore>
+    </rng:choice>
   </content>
   <constraintSpec scheme="schematron" ident="sch-el-quote" mode="add">
     <desc versionDate="2023-05-31" xml:lang="en">Schematron rules for tei:quote</desc>

--- a/tests/src/schema/elements/test_quote.py
+++ b/tests/src/schema/elements/test_quote.py
@@ -20,6 +20,12 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
             "<quote type='fully_inserted' source='http://foo.bar'>bar baz foo</quote>",
             True,
         ),
+        ("valid-quote-with-two-segs", "<quote><seg>1</seg><seg>2</seg></quote>", True),
+        (
+            "invalid-quote-with-two-seg-default-mixed",
+            "<quote><seg>1</seg>baz</quote>",
+            False,
+        ),
         (
             "quote-with-invalid-attribute",
             "<quote xml:lang='fr'>bar baz foo</quote>",


### PR DESCRIPTION
This also allows tei:seg, but not a mixed model with ssrq.content.default and tei:seg.
