### PR TITLE
feat: allow attribute n for tei:p

### DIFF
--- a/src/schema/elements/p.xml
+++ b/src/schema/elements/p.xml
@@ -46,7 +46,6 @@
     </constraint>
   </constraintSpec>
   <attList>
-    <attDef ident="n" mode="delete"/>
     <attDef ident="xml:id" mode="delete"/>
   </attList>
   <xi:include href="examples.xml" xpointer="ex-p-seg-de"/>

--- a/tests/src/schema/elements/test_p.py
+++ b/tests/src/schema/elements/test_p.py
@@ -17,7 +17,7 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
         ),
         (
             "valid-simple-p-with-attr",
-            "<p xml:lang='de'>foo</p>",
+            "<p xml:lang='de' n='1'>foo</p>",
             True,
         ),
         (
@@ -27,12 +27,7 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
         ),
         (
             "simple-p-with-invalid-attr",
-            "<p rend='black'>foo</p>",
-            False,
-        ),
-        (
-            "simple-p-with-invalid-attr",
-            "<p xml:id='facs'>foo</p>",
+            "<p rend='black' xml:id='facs'>foo</p>",
             False,
         ),
     ],


### PR DESCRIPTION
This commit allows the n-attribute for tei:p to make nested tei:seg-elements for numeration purposes unnecessary.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
