### PR TITLE
feat: allowed tei:ab in tei:body

### DIFF
--- a/src/schema/elements/body.xml
+++ b/src/schema/elements/body.xml
@@ -18,6 +18,7 @@
   <classes mode="replace"/>
   <content>
     <sequence preserveOrder="false">
+      <elementRef key="ab" minOccurs="0" maxOccurs="unbounded"/>
       <elementRef key="div" maxOccurs="unbounded"/>
       <elementRef key="gap" minOccurs="0" maxOccurs="unbounded"/>
       <elementRef key="pb" minOccurs="0" maxOccurs="unbounded"/>

--- a/src/schema/examples/body.xml
+++ b/src/schema/examples/body.xml
@@ -8,9 +8,7 @@
     </div>
     <gap/>
     <pb/>
-    <div>
-      <ab type="sigillant" place="plica">...</ab>
-      <ab type="sigillant" place="plica">...</ab>
-    </div>
+    <ab type="sigillant" place="plica">...</ab>
+    <ab type="dorsal" place="verso">...</ab>
   </body>
 </egXML>

--- a/tests/src/schema/elements/test_body.py
+++ b/tests/src/schema/elements/test_body.py
@@ -17,8 +17,8 @@ from ..conftest import RNG_test_function
             True,
         ),
         (
-            "valid-body-with-pb-div",
-            "<body><pb n='1' facs='abcde_1'/><div><p>bar</p></div></body>",
+            "valid-body-with-multiple-elements",
+            "<body><pb n='1' facs='abcde_1'/><div><p>bar</p></div><gap/><ab type='dorsal' place='verso'>foo</ab></body>",
             True,
         ),
         (


### PR DESCRIPTION
tei:ab may now be used directly inside tei:body. So one does not have to use unnecessary tei:div-elements.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
