### PR TITLE
[feat]: extend content model for tei:seg

### DIFF
--- a/src/schema/elements/seg.xml
+++ b/src/schema/elements/seg.xml
@@ -17,12 +17,13 @@
   </classes>
   <content>
     <rng:choice>
-      <rng:group>
-        <rng:ref name="p"/>
-        <rng:oneOrMore>
+      <rng:oneOrMore>
+        <rng:choice>
           <rng:ref name="p"/>
-        </rng:oneOrMore>
-      </rng:group>
+          <rng:ref name="add"/>
+          <rng:ref name="head"/>
+        </rng:choice>
+      </rng:oneOrMore>
       <rng:group>
         <rng:ref name="seg"/>
         <rng:oneOrMore>

--- a/tests/src/schema/elements/test_seg.py
+++ b/tests/src/schema/elements/test_seg.py
@@ -26,6 +26,16 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
             True,
         ),
         (
+            "valid-seg-with-p-and-other-content",
+            "<seg><head>foo</head><p><lb/>Und sonderlich sol soͤlich unser gebott</p><add place='left_top'>baz</add></seg>",
+            True,
+        ),
+        (
+            "invalid-seg-with-p-and-other-content",
+            "<seg><head>foo</head><p><lb/>Und sonderlich sol soͤlich unser gebott</p><add place='left_top'>baz</add><note>lorem ipsum</note></seg>",
+            False,
+        ),
+        (
             "seg-with-invalid-child",
             "<seg n='1'><text>foo</text></seg>",
             False,


### PR DESCRIPTION
This commit allows the mixed usage of p, head and add as childs of seg.
