### PR TITLE
feat: changed order of tei:subst child elements

### DIFF
--- a/src/schema/elements/subst.xml
+++ b/src/schema/elements/subst.xml
@@ -8,7 +8,7 @@
   <desc xml:lang="fr" versionDate="2023-07-31">Contient un remplacement.</desc>
   <classes mode="replace"/>
   <content>
-    <sequence>
+    <sequence preserveOrder="false">
       <elementRef key="del"/>
       <elementRef key="add"/>
     </sequence>
@@ -16,19 +16,22 @@
   <xi:include href="examples.xml" xpointer="ex-subst-de"/>
   <xi:include href="examples.xml" xpointer="ex-subst-en"/>
   <xi:include href="examples.xml" xpointer="ex-subst-fr"/>
-  <remarks xml:lang="de" versionDate="2023-08-02">
-    <p>Gruppiert eine oder mehrere Tilgungen (oder überschüssigen Text) mit einer oder mehreren Hinzufügungen, wenn
-            die Kombination als einzelner Eingriff in den Text zu betrachten ist.
+  <remarks xml:lang="de" versionDate="2023-11-16">
+    <p>Gruppiert eine Tilgung (oder überschüssigen Text) mit einer Hinzufügung
+        in beliebiger Reihenfolge, wenn die Kombination als einzelner Eingriff
+        in den Text zu betrachten ist.
         </p>
   </remarks>
-  <remarks xml:lang="en" versionDate="2023-08-02">
-    <p>Groups one deletion with one addition when the combination is to be
-            considered a single intrusion into the text.
+  <remarks xml:lang="en" versionDate="2023-11-16">
+    <p>Groups one deletion (or excess text) with one addition
+        in any order if the combination should be considered
+            as a single intervention in the text.
         </p>
   </remarks>
-  <remarks xml:lang="fr" versionDate="2023-08-02">
-    <p>Regroupe une suppression avec un ajout lorsque la combinaison
-            doit être considérée comme une seule intrusion dans le texte.
+  <remarks xml:lang="fr" versionDate="2023-11-16">
+    <p>Regroupe une suppression (ou un excès de texte) avec un ajout
+        dans n'importe quel ordre si la combinaison doit être considérée
+            comme une seule intervention dans le texte.
         </p>
   </remarks>
 </elementSpec>

--- a/tests/src/schema/elements/test_subst.py
+++ b/tests/src/schema/elements/test_subst.py
@@ -14,7 +14,7 @@ from ..conftest import RNG_test_function
         (
             "valid-subst-add-first",
             "<subst><add place='left_top'>bar</add><del>foo</del></subst>",
-            False,
+            True,
         ),
         (
             "invalid-subst-with-attributes",


### PR DESCRIPTION
This commit makes the order of tei:del and tei:add inside tei:subst arbitrary.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
