### PR TITLE
[fix]: regex in regular idno-constraint

### DIFF
--- a/src/schema/elements/idno.xml
+++ b/src/schema/elements/idno.xml
@@ -38,7 +38,7 @@
       </sch:pattern>
       <sch:pattern>
         <sch:rule context="tei:idno[parent::tei:seriesStmt][not(@type)]">
-          <sch:assert test="matches(., '^(SSRQ|SDS|FDS)-([A-Z]{2})-([A-Za-z0-9_]+)-(?:((?:[A-Za-z0-9]+\.)*)([0-9]+)(?:-([0-9]+)|([a-z]{3,})?))$')">
+          <sch:assert test="matches(., '^(SSRQ|SDS|FDS)-([A-Z]{2})-([A-Za-z0-9_]+)-(?:((?:[A-Za-z0-9]+\.)*)([0-9]+)(?:-([0-9]+))?|([a-z]{3,}))$')">
                         The idno must match the defined schema – see the examples in the docs.
                     </sch:assert>
         </sch:rule>

--- a/tests/src/schema/elements/test_idno.py
+++ b/tests/src/schema/elements/test_idno.py
@@ -46,8 +46,28 @@ def test_idno(
             True,
         ),
         (
-            "valid-series-idno",
+            "valid-series-idno-without-tradtion-part",
             "<seriesStmt><idno>SSRQ-SG-III_4-77</idno></seriesStmt>",
+            True,
+        ),
+        (
+            "valid-series-idno",
+            "<seriesStmt><idno>SSRQ-FR-I_2_8-1-1</idno></seriesStmt>",
+            True,
+        ),
+        (
+            "valid-series-idno-with-case",
+            "<seriesStmt><idno>SDS-NE-4-1.0-1</idno></seriesStmt>",
+            True,
+        ),
+        (
+            "valid-series-idno-with-case-and-opening",
+            "<seriesStmt><idno>SDS-NE-4-1.A.1-1</idno></seriesStmt>",
+            True,
+        ),
+        (
+            "valid-series-idno-for-paratext",
+            "<seriesStmt><idno>SDS-NE-4-lit</idno></seriesStmt>",
             True,
         ),
         (


### PR DESCRIPTION
The constraint before would would lead to invalid idnos for editorial paratexts. The corrected regex does no correctly respect them as well as idnos without a tradition part
