### PR TITLE
feat/refac: units for tei:measure

### DIFF
--- a/src/schema/commons/classes.odd.xml
+++ b/src/schema/commons/classes.odd.xml
@@ -572,7 +572,6 @@
               <rng:ref name="ssrq.measure.capacity"/>
               <rng:ref name="ssrq.measure.currency"/>
               <rng:ref name="ssrq.measure.lengths.base.cm"/>
-              <rng:ref name="ssrq.measure.lengths.base.klafter"/>
               <rng:ref name="ssrq.measure.length"/>
               <rng:ref name="ssrq.measure.various"/>
               <rng:ref name="ssrq.measure.weight"/>

--- a/src/schema/commons/datatypes.odd.xml
+++ b/src/schema/commons/datatypes.odd.xml
@@ -1027,6 +1027,11 @@
           <desc xml:lang="fr" type="singular" versionDate="2023-03-17">kammer</desc>
           <desc xml:lang="fr" type="plural" versionDate="2023-03-17">kammern</desc>
         </valItem>
+        <valItem ident="Klafter">
+          <desc xml:lang="de" versionDate="2023-03-17">Klafter</desc>
+          <desc xml:lang="en" versionDate="2023-03-17">klafter</desc>
+          <desc xml:lang="fr" versionDate="2023-05-15">brasses</desc>
+        </valItem>
         <valItem ident="Kuhsömmerung">
           <desc xml:lang="de" type="singular" versionDate="2023-03-17">Kuhsömmerung</desc>
           <desc xml:lang="de" type="plural" versionDate="2023-03-17">Kuhsömmerungen</desc>
@@ -1072,6 +1077,14 @@
           <desc xml:lang="de" type="plural" versionDate="2023-03-17">Ruten</desc>
           <desc xml:lang="en" versionDate="2023-03-17">rod</desc>
           <desc xml:lang="fr" versionDate="2023-03-17">perche</desc>
+        </valItem>
+        <valItem ident="Schuh">
+          <desc xml:lang="de" type="singular" versionDate="2023-03-17">Schuh</desc>
+          <desc xml:lang="de" type="plural" versionDate="2023-03-17">Schuhe</desc>
+          <desc xml:lang="en" type="singular" versionDate="2023-03-17">shoe</desc>
+          <desc xml:lang="en" type="plural" versionDate="2023-03-17">shoes</desc>
+          <desc xml:lang="fr" type="singular" versionDate="2023-03-17">chaussure</desc>
+          <desc xml:lang="fr" type="plural" versionDate="2023-03-17">chaussures</desc>
         </valItem>
         <valItem ident="Schuppose">
           <desc xml:lang="de" type="singular" versionDate="2023-03-17">Schuppose</desc>
@@ -1147,6 +1160,11 @@
             <desc xml:lang="en" type="plural" versionDate="2023-03-17">pots</desc>
             <desc xml:lang="fr" type="singular" versionDate="2023-09-15">channe</desc>
             <desc xml:lang="fr" type="plural" versionDate="2023-09-15">channes</desc>
+          </valItem>
+          <valItem ident="Klafter">
+            <desc xml:lang="de" versionDate="2023-03-17">Klafter</desc>
+            <desc xml:lang="en" versionDate="2023-03-17">klafter</desc>
+            <desc xml:lang="fr" versionDate="2023-05-15">brasses</desc>
           </valItem>
           <valItem ident="Kopf">
             <desc xml:lang="de" type="singular" versionDate="2023-03-17">Kopf</desc>
@@ -1637,6 +1655,11 @@
             <desc xml:lang="fr" type="singular" versionDate="2023-03-17">pied</desc>
             <desc xml:lang="fr" type="plural" versionDate="2023-03-17">pieds</desc>
           </valItem>
+          <valItem ident="Klafter">
+            <desc xml:lang="de" versionDate="2023-03-17">Klafter</desc>
+            <desc xml:lang="en" versionDate="2023-03-17">klafter</desc>
+            <desc xml:lang="fr" versionDate="2023-05-15">brasses</desc>
+          </valItem>
           <valItem ident="Meile">
             <desc xml:lang="de" type="singular" versionDate="2023-03-17">Meile</desc>
             <desc xml:lang="de" type="plural" versionDate="2023-03-17">Meilen</desc>
@@ -1685,17 +1708,6 @@
             <desc xml:lang="de" versionDate="2023-03-17">cm</desc>
             <desc xml:lang="en" versionDate="2023-03-17">cm</desc>
             <desc xml:lang="fr" versionDate="2023-03-17">cm</desc>
-          </valItem>
-        </valList>
-      </content>
-    </dataSpec>
-    <dataSpec ident="ssrq.measure.lengths.base.klafter">
-      <content>
-        <valList type="closed">
-          <valItem ident="Klafter">
-            <desc xml:lang="de" versionDate="2023-03-17">Klafter</desc>
-            <desc xml:lang="en" versionDate="2023-03-17">klafter</desc>
-            <desc xml:lang="fr" versionDate="2023-05-15">brasses</desc>
           </valItem>
         </valList>
       </content>

--- a/src/schema/elements/measure.xml
+++ b/src/schema/elements/measure.xml
@@ -33,7 +33,7 @@
                     </sch:assert>
         </sch:rule>
         <sch:rule context="tei:measure[@type = 'area']">
-          <sch:let name="area" value="{{concat('&quot;', string-join(//tei:dataSpec[@ident = ('ssrq.measure.area', 'ssrq.measure.lengths.base.klafter')]//tei:valItem/@ident, '|'), '&quot;')}}"/>
+          <sch:let name="area" value="{{concat('&quot;', string-join(//tei:dataSpec[@ident = ('ssrq.measure.area')]//tei:valItem/@ident, '|'), '&quot;')}}"/>
           <sch:assert test="matches(@unit, concat('^', $area, '$'))"><sch:value-of select="./@unit"/>
                         is not a valid area measurement – you need to choose
                         from the following list:
@@ -49,7 +49,7 @@
                     </sch:assert>
         </sch:rule>
         <sch:rule context="tei:measure[@type = 'length']">
-          <sch:let name="length" value="{{concat('&quot;', string-join(sort(//tei:dataSpec[@ident = ('ssrq.measure.length', 'ssrq.measure.lengths.base.cm', 'ssrq.measure.parts.vierling', 'ssrq.measure.lengths.base.klafter')]//tei:valItem/@ident), '|'), '&quot;')}}"/>
+          <sch:let name="length" value="{{concat('&quot;', string-join(sort(//tei:dataSpec[@ident = ('ssrq.measure.length', 'ssrq.measure.lengths.base.cm', 'ssrq.measure.parts.vierling')]//tei:valItem/@ident), '|'), '&quot;')}}"/>
           <sch:assert test="matches(@unit, concat('^', $length, '$'))"><sch:value-of select="./@unit"/>
                         is not valid length measurement– you need to choose
                         from the following list:
@@ -84,7 +84,7 @@
                     </sch:assert>
         </sch:rule>
         <sch:rule context="tei:measure[@type = 'volume']">
-          <sch:let name="volume" value="{{concat('&quot;', string-join(sort(//tei:dataSpec[@ident = ('ssrq.measure.lengths.base.klafter', 'ssrq.measure.capacity', 'ssrq.measure.parts.vierling')]//tei:valItem/@ident), '|'), '&quot;')}}"/>
+          <sch:let name="volume" value="{{concat('&quot;', string-join(sort(//tei:dataSpec[@ident = ('ssrq.measure.capacity', 'ssrq.measure.parts.vierling')]//tei:valItem/@ident), '|'), '&quot;')}}"/>
           <sch:assert test="matches(@unit, concat('^', $volume, '$'))"><sch:value-of select="./@unit"/>
                         is not valid capacity measurement– you need to choose
                         from the following list:


### PR DESCRIPTION
This commit changes the following:
- "Schuh" is now a length and an area unit.
- "Klafter" is now a length, an area and a capacity unit.
- "Klafter" is no longer in a separate datatype.

Pro: It is not necessary to separatly process "Klafter" and "Schuh" in Schematron rules.
Con: These units are now duplicated in different tei:dataSpec-elements

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
