### PR TITLE
feat: allow lb in subst

### DIFF
--- a/src/schema/elements/subst.xml
+++ b/src/schema/elements/subst.xml
@@ -9,13 +9,17 @@
   <classes mode="replace"/>
   <content>
     <sequence preserveOrder="false">
-      <elementRef key="del"/>
       <elementRef key="add"/>
+      <elementRef key="del"/>
+      <elementRef key="lb" minOccurs="0"/>
     </sequence>
   </content>
   <xi:include href="examples.xml" xpointer="ex-subst-de"/>
   <xi:include href="examples.xml" xpointer="ex-subst-en"/>
   <xi:include href="examples.xml" xpointer="ex-subst-fr"/>
+  <xi:include href="examples.xml" xpointer="ex-subst-lb-de"/>
+  <xi:include href="examples.xml" xpointer="ex-subst-lb-en"/>
+  <xi:include href="examples.xml" xpointer="ex-subst-lb-fr"/>
   <remarks xml:lang="de" versionDate="2023-11-16">
     <p>Gruppiert eine Tilgung (oder überschüssigen Text) mit einer Hinzufügung
         in beliebiger Reihenfolge, wenn die Kombination als einzelner Eingriff

--- a/src/schema/examples/examples.xml
+++ b/src/schema/examples/examples.xml
@@ -1674,15 +1674,27 @@
     </exemplum>
     <exemplum xml:lang="de" xml:id="ex-subst-de">
       <p>Beispiel für eine Ersetzung</p>
-      <xi:include href="subst.xml"/>
+      <xi:include href="subst.xml" xpointer="ex-subst"/>
     </exemplum>
     <exemplum xml:lang="en" xml:id="ex-subst-en">
       <p>Example of a replacement</p>
-      <xi:include href="subst.xml"/>
+      <xi:include href="subst.xml" xpointer="ex-subst"/>
     </exemplum>
     <exemplum xml:lang="fr" xml:id="ex-subst-fr">
       <p>Exemple de remplacement</p>
-      <xi:include href="subst.xml"/>
+      <xi:include href="subst.xml" xpointer="ex-subst"/>
+    </exemplum>
+    <exemplum xml:lang="de" xml:id="ex-subst-lb-de">
+      <p>Beispiel für eine Ersetzung mit Zeilenumbruch</p>
+      <xi:include href="subst.xml" xpointer="ex-subst-lb"/>
+    </exemplum>
+    <exemplum xml:lang="en" xml:id="ex-subst-lb-en">
+      <p>Example of a replacement with a line break</p>
+      <xi:include href="subst.xml" xpointer="ex-subst-lb"/>
+    </exemplum>
+    <exemplum xml:lang="fr" xml:id="ex-subst-lb-fr">
+      <p>Exemple de remplacementavec un saut de ligne</p>
+      <xi:include href="subst.xml" xpointer="ex-subst-lb"/>
     </exemplum>
     <exemplum xml:lang="de" xml:id="ex-supplied-de">
       <p>Beispiel für eine Ergänzung</p>

--- a/src/schema/examples/subst.xml
+++ b/src/schema/examples/subst.xml
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-  <subst>
-    <del>zugeschafft</del>
-    <add place="above">angethan</add>
-  </subst>
-</egXML>
+<div xmlns="http://www.tei-c.org/ns/1.0">
+  <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="ex-subst">
+    <subst>
+      <del>zugeschafft</del>
+      <add place="above">angethan</add>
+    </subst>
+  </egXML>
+  <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="ex-subst-lb">
+    <subst>
+      <del>ihr gnaden</del>
+      <lb/>
+      <add hand="hand17c" place="left margin">man</add>
+    </subst>
+  </egXML>
+</div>

--- a/tests/src/schema/elements/test_subst.py
+++ b/tests/src/schema/elements/test_subst.py
@@ -17,6 +17,11 @@ from ..conftest import RNG_test_function
             True,
         ),
         (
+            "valid-subst-with-lb",
+            "<subst><del>foo</del><lb/><add place='inline'>bar</add></subst>",
+            True,
+        ),
+        (
             "invalid-subst-with-attributes",
             "<subst type='bla'><add place='left_top'>bar</add><del>foo</del></subst>",
             False,


### PR DESCRIPTION
This commit allows an optional tei:lb in tei:subst. Adjusted examples and added test case.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
