### PR TITLE
[ci/build]: deactivate snakemd info logger

### DIFF
--- a/utils/commons/logger.py
+++ b/utils/commons/logger.py
@@ -11,6 +11,10 @@ def setup_logger():
         handlers=[rich_logging.RichHandler()],
     )
 
+    # disable snakemd logger by setting it to ERROR
+    snakemd_logger = logging.getLogger("snakemd")
+    snakemd_logger.setLevel(logging.ERROR)
+
     return logging.getLogger("rich")
 
 


### PR DESCRIPTION
The changes introduced in the previous verison of SnakeMD changed the loglevel from 'DEBUG' to 'INFO', which created a lot of logs when building the docs. This commit turns of the SnakeMD logger by setting it's default level 'ERROR'.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->
See commit details

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [x] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
