### PR TITLE
feat: added Vierling as area unit

### DIFF
--- a/src/schema/commons/datatypes.odd.xml
+++ b/src/schema/commons/datatypes.odd.xml
@@ -1123,6 +1123,13 @@
           <desc xml:lang="en" versionDate="2023-03-17">tagwen</desc>
           <desc xml:lang="fr" versionDate="2023-03-17">tagwen</desc>
         </valItem>
+        <valItem ident="Vierling">
+          <desc xml:lang="de" versionDate="2023-03-17">Vierling</desc>
+          <desc xml:lang="en" type="singular" versionDate="2023-03-17">quarter</desc>
+          <desc xml:lang="en" type="plural" versionDate="2023-03-17">quarters</desc>
+          <desc xml:lang="fr" type="singular" versionDate="2023-03-17">un quart</desc>
+          <desc xml:lang="fr" type="plural" versionDate="2023-03-17">quarts</desc>
+        </valItem>
       </valList>
     </dataSpec>
     <dataSpec ident="ssrq.measure.capacity">


### PR DESCRIPTION
This commit allows the usage of "Vierling" as a valid unit for area measurements.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
