### PR TITLE
fix: unit Linie

### DIFF
--- a/src/schema/commons/datatypes.odd.xml
+++ b/src/schema/commons/datatypes.odd.xml
@@ -1232,14 +1232,6 @@
             <desc xml:lang="en" versionDate="2023-03-17">legel</desc>
             <desc xml:lang="fr" versionDate="2023-03-17">legel</desc>
           </valItem>
-          <valItem ident="Linie">
-            <desc xml:lang="de" type="singular" versionDate="2023-03-17">Linie</desc>
-            <desc xml:lang="de" type="plural" versionDate="2023-03-17">Linien</desc>
-            <desc xml:lang="en" type="singular" versionDate="2023-03-17">line</desc>
-            <desc xml:lang="en" type="plural" versionDate="2023-03-17">lines</desc>
-            <desc xml:lang="fr" type="singular" versionDate="2023-03-17">ligne</desc>
-            <desc xml:lang="fr" type="plural" versionDate="2023-03-17">lignes</desc>
-          </valItem>
           <valItem ident="Mass">
             <desc xml:lang="de" versionDate="2023-03-17">Mass</desc>
             <desc xml:lang="en" versionDate="2023-03-17">mass</desc>
@@ -1705,6 +1697,14 @@
             <desc xml:lang="de" versionDate="2023-03-17">Klafter</desc>
             <desc xml:lang="en" versionDate="2023-03-17">klafter</desc>
             <desc xml:lang="fr" versionDate="2023-05-15">brasses</desc>
+          </valItem>
+          <valItem ident="Linie">
+            <desc xml:lang="de" type="singular" versionDate="2023-03-17">Linie</desc>
+            <desc xml:lang="de" type="plural" versionDate="2023-03-17">Linien</desc>
+            <desc xml:lang="en" type="singular" versionDate="2023-03-17">line</desc>
+            <desc xml:lang="en" type="plural" versionDate="2023-03-17">lines</desc>
+            <desc xml:lang="fr" type="singular" versionDate="2023-03-17">ligne</desc>
+            <desc xml:lang="fr" type="plural" versionDate="2023-03-17">lignes</desc>
           </valItem>
           <valItem ident="Meile">
             <desc xml:lang="de" type="singular" versionDate="2023-03-17">Meile</desc>


### PR DESCRIPTION
This commit makes "Linie" a unit for length instead of a unit for capacity.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
