### PR TITLE
feat: allow tei:cb in tei:seg and tei:table

### DIFF
--- a/src/schema/elements/seg.xml
+++ b/src/schema/elements/seg.xml
@@ -20,6 +20,7 @@
       <rng:oneOrMore>
         <rng:choice>
           <rng:ref name="add"/>
+          <rng:ref name="cb"/>
           <rng:ref name="head"/>
           <rng:ref name="p"/>
           <rng:ref name="pb"/>

--- a/src/schema/elements/table.xml
+++ b/src/schema/elements/table.xml
@@ -10,6 +10,7 @@
   <content>
     <sequence preserveOrder="false">
       <alternate minOccurs="0" maxOccurs="unbounded">
+        <elementRef key="cb"/>
         <elementRef key="head"/>
         <elementRef key="pb"/>
       </alternate>

--- a/tests/src/schema/elements/test_seg.py
+++ b/tests/src/schema/elements/test_seg.py
@@ -27,7 +27,7 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
         ),
         (
             "valid-seg-with-p-and-other-content",
-            "<seg><head>foo</head><p><lb/>Und sonderlich sol soͤlich unser gebott</p><add place='left_top'>baz</add><table><row><cell>foo</cell></row></table></seg>",
+            "<seg><head>foo</head><pb/><cb/><p><lb/>Und sonderlich sol soͤlich unser gebott</p><add place='left_top'>baz</add><cb/><table><row><cell>foo</cell></row></table></seg>",
             True,
         ),
         (

--- a/tests/src/schema/elements/test_table.py
+++ b/tests/src/schema/elements/test_table.py
@@ -22,8 +22,8 @@ from ..conftest import RNG_test_function
             True,
         ),
         (
-            "valid-table-with-head-and-pb",
-            "<table><head>bar</head> <pb n='32' facs='fol_32v'/><row><cell>foo</cell></row></table>",
+            "valid-table-with-head-and-breaks",
+            "<table><head>bar</head> <pb n='32' facs='fol_32v'/><cb n='a'/><row><cell>foo</cell></row><cb n='b'/></table>",
             True,
         ),
         (


### PR DESCRIPTION
This commit allows the usage of tei:cb inside tei:seg and tei:table in analogy to tei:pb, which was already allowed there.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
