### PR TITLE
feat: added schematron rule for @quantity

### DIFF
--- a/src/schema/commons/classes.odd.xml
+++ b/src/schema/commons/classes.odd.xml
@@ -326,6 +326,18 @@
           </sch:pattern>
         </constraint>
       </constraintSpec>
+      <constraintSpec scheme="schematron" ident="sch-att-dimensions-3">
+        <desc xml:lang="en" versionDate="2024-01-24">Prevent that quantity is zero</desc>
+        <constraint>
+          <sch:pattern>
+            <sch:rule context="tei:*[number(@quantity)=0 or number(@quantity)=0.0]">
+              <sch:report test="not(@type='currency')" xml:lang="en">
+                  @quantity may only be zero, if it occurs in combination with @type="currency".
+              </sch:report>
+            </sch:rule>
+          </sch:pattern>
+        </constraint>
+      </constraintSpec>
       <attList>
         <attDef ident="extent" mode="delete"/>
         <attDef ident="precision" mode="delete"/>

--- a/tests/src/schema/test_constraints.py
+++ b/tests/src/schema/test_constraints.py
@@ -73,6 +73,38 @@ def test_dependency_of_unit_and_quantity(
     "name, markup, result",
     [
         (
+            "invalid-quantity-with-zero-length",
+            """
+             <p>
+                <height unit='cm' quantity='0'/>
+                <width unit='cm' quantity='0.0'/>
+                <measure type="length" unit="cm" quantity="00">0 cm</measure>
+             </p>
+            """,
+            False,
+        ),
+        (
+            "valid-quantity-with-zero-currency",
+            "<measure type='currency' unit='lb' quantity='0'>0 lb</measure>",
+            True,
+        ),
+    ],
+)
+def test_quantity_constraint(
+    main_constraints: str, writer: SimpleTEIWriter, name: str, markup: str, result: bool
+):
+    """Test if the validation fails, when an attribute starts with whitespace."""
+    writer.write(name, add_tei_namespace(markup))
+    reports: list[SchematronResult] = validate_chunk(
+        files=writer.list(), isosch=main_constraints
+    )
+    assert reports[0].is_valid() is result
+
+
+@pytest.mark.parametrize(
+    "name, markup, result",
+    [
+        (
             "correct-facs",
             "<pb facs='foo_1r'/>",
             True,


### PR DESCRIPTION
This commit prevents that any quantity attribute is zero except when there is an attribute type with the value of currency.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
