### PR TITLE
feat: allow @from-custom and @to-custom in tei:date

### DIFF
--- a/src/schema/elements/date.xml
+++ b/src/schema/elements/date.xml
@@ -33,17 +33,18 @@
                     </sch:assert>
         </sch:rule>
         <sch:rule context="tei:date[ancestor::tei:publicationStmt]">
-          <sch:assert test=".[@type][@type/data(.) = ('electronic', 'print')]">If
+          <sch:assert test=".[@type][@type/data(.) = ('electronic', 'print')]">
+                        If
                         <sch:name/>
                         is part of the publicationStmt it must contain @type with a value of
                         electronic or print.
                     </sch:assert>
-          <sch:assert test=".[@when-custom][not(@calendar|@dur-iso|@from-custom|@to-custom|@notAfter-custom|@notBefore-custom|@period)]">
+          <sch:assert test=".[@when-custom or (@from-custom and @to-custom)][not(@calendar|@dur-iso|@notAfter-custom|@notBefore-custom|@period)]">
                         If
                         <sch:name/>
-                        is part of the publicationStmt it must contain @when-custom and may not contain
-                        @calendar, @dur-iso, @from-custom, @to-custom, @notAfter-custom, @notBefore-custom or
-                        @period.
+                        is part of the publicationStmt it must contain @when-custom or @from-custom
+                        and to-custom, and may not contain @calendar, @dur-iso, @notAfter-custom,
+                        @notBefore-custom or @period.
                     </sch:assert>
           <sch:assert test="string-length(normalize-space(.)) = 0 and not(child::*)">
                         If

--- a/tests/src/schema/elements/test_date.py
+++ b/tests/src/schema/elements/test_date.py
@@ -161,8 +161,18 @@ def test_date_rng(
         ),
         (
             "valid-date-inside-pubStmt",
-            "<publicationStmt><date type='electronic' when-custom='2019-08-15'/></publicationStmt>",
+            "<publicationStmt><date type='print' when-custom='2019-08-15'/></publicationStmt>",
             True,
+        ),
+        (
+            "valid-date-inside-pubStmt-from-to",
+            "<publicationStmt><date type='electronic' from-custom='2019-01-01' to-custom='2019-12-31'/></publicationStmt>",
+            True,
+        ),
+        (
+            "invalid-date-inside-pubStmt-from",
+            "<publicationStmt><date type='print' from-custom='2019-01-01'/></publicationStmt>",
+            False,
         ),
         (
             "invalid-date-inside-pubStmt",


### PR DESCRIPTION
This commit allows the usage of @from-custom and @to-custom in tei:date when tei:date is inside tei:publicationStmt

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
