### PR TITLE
fix: schematron rule for tei:msDesc to allow missing physDesc/adminInfo

### DIFF
--- a/src/schema/elements/msDesc.xml
+++ b/src/schema/elements/msDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl"
-        type="application/xml"
-        schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+    type="application/xml"
+    schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" ident="msDesc" module="msdescription" mode="change">
   <desc xml:lang="de" versionDate="2023-05-30">Beschreibt das edierte Quellenstück mit
         Aufbewahrungsort, Material, Layout, Schreiber, Siegel und Bibliographie zu Sekundärliteratur
@@ -32,7 +32,10 @@
     <desc xml:lang="en" versionDate="2023-03-07">Constraint for tei:msDesc to ensure the usage of either tei:physDesc or tei:adminInfo.</desc>
     <constraint>
       <sch:pattern>
-        <sch:rule context="tei:msDesc[not(tei:physDesc)]">
+        <sch:rule context="tei:msDesc[ancestor::tei:TEI//tei:text[@type = 'collection']]">
+          <sch:assert test=".[not(//tei:adminInfo)][not(tei:physDesc)]">Neither tei:physDesc nor tei:adminInfo are allowed for documents with tei:text/@type = 'collection'.</sch:assert>
+        </sch:rule>
+        <sch:rule context="tei:msDesc[not(tei:physDesc)][not(ancestor::tei:TEI//tei:text[@type = 'collection'])]">
           <sch:assert test=".[//tei:adminInfo]">If no tei:physDesc is given, tei:adminInfo is required!</sch:assert>
         </sch:rule>
       </sch:pattern>

--- a/tests/src/schema/elements/test_msDesc.py
+++ b/tests/src/schema/elements/test_msDesc.py
@@ -47,6 +47,16 @@ def test_msDesc(
             True,
         ),
         (
+            "valid-msDesc-without-physDesc-and-adminInfo-and-text-type-collection",
+            "<TEI><msDesc><history/></msDesc><text type='collection'/></TEI>",
+            True,
+        ),
+        (
+            "invalid-msDesc-without-physDesc-and-adminInfo-and-text-type-transcript",
+            "<TEI><msDesc><history/></msDesc><text type='transcript'/></TEI>",
+            False,
+        ),
+        (
             "invalid-msDesc-without-physDesc-and-without-adminInfo",
             "<msDesc></msDesc>",
             False,


### PR DESCRIPTION
If the tei:text has an type 'collection' there should no be physDesc or adminInfo given, because there is no real document. This commit extends the previous rule and makes data-hacks obsolete.
