### PR TITLE
feat: added constraint for tei:note

### DIFF
--- a/src/schema/elements/note.xml
+++ b/src/schema/elements/note.xml
@@ -47,10 +47,14 @@
                         A note inside a critical apparatus must have a type attribute.
                     </sch:assert>
         </sch:rule>
-        <sch:rule context="tei:note[@type = 'text_comparison']">
+        <sch:rule context="tei:note[@type='text_comparison']">
           <sch:assert test="parent::tei:app">
                         A note with type "text_comparison" must be inside a critical apparatus.
                     </sch:assert>
+        </sch:rule>
+        <sch:rule context="tei:note[not(@type='original')]">
+          <sch:report test="./@place">Attribute place is only allowed if attribute type has the value "original".
+            </sch:report>
         </sch:rule>
       </sch:pattern>
     </constraint>

--- a/tests/src/schema/elements/test_note.py
+++ b/tests/src/schema/elements/test_note.py
@@ -72,6 +72,16 @@ def test_note(
             "<app><note type='text_comparison'><ref target='http://example.com'/><ref target='http://example.org'/><orig>foo</orig></note></app>",
             False,
         ),
+        (
+            "valid-note-with-place",
+            "<note type='original' place='above'>Foo</note>",
+            True,
+        ),
+        (
+            "invalid-note-with-place",
+            "<note place='above'>Foo</note>",
+            False,
+        ),
     ],
 )
 def test_note_constraints(


### PR DESCRIPTION
This constraint forbids the usage of @place when @type is not "original", because the place of a note is only reasonable if it is an original note present in the manuscript.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
