### PR TITLE
fix: removed unnecessary attributes

### DIFF
--- a/src/schema/elements/list.xml
+++ b/src/schema/elements/list.xml
@@ -31,6 +31,7 @@
         </valItem>
       </valList>
     </attDef>
+    <attDef ident="type" mode="delete"/>
   </attList>
   <xi:include href="examples.xml" xpointer="ex-list-de"/>
   <xi:include href="examples.xml" xpointer="ex-list-en"/>

--- a/src/schema/elements/title.xml
+++ b/src/schema/elements/title.xml
@@ -26,6 +26,7 @@
   <attList>
     <attDef ident="level" mode="delete"/>
     <attDef ident="n" mode="delete"/>
+    <attDef ident="type" mode="delete"/>
     <attDef ident="xml:id" mode="delete"/>
   </attList>
   <xi:include href="examples.xml" xpointer="ex-title-de"/>


### PR DESCRIPTION
# Pull request

This pull request removes two unnecessary attributes @type from list and title,
which are defined in the TEI-Guidelines in both element definitions but not in
the class att.typed.

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
