### PR TITLE
feat: simplified regular expression for validation of tei:idno(s)

### DIFF
--- a/src/schema/commons/patterns.odd.xml
+++ b/src/schema/commons/patterns.odd.xml
@@ -182,7 +182,7 @@
                 référence à d'autres pièces TEI y compris les identificateurs de fragments.
             </desc>
       <content>
-        <dataRef name="string" restriction="urn:ssrq:(SSRQ|SDS|FDS)-([A-Z]{2})-([A-Za-z0-9_]+)-((([A-Za-z0-9]+\.)*)([0-9]+)(-([0-9]+))?|([a-z]{3,}))(#(\d+|fol\d+[rv](\-\d+[rv])?|[pn]\d+(\.\d+)?(\-\d+(\.\d+)?)?))?"/>
+        <dataRef name="string" restriction="urn:ssrq:(SSRQ|SDS|FDS)-([A-Z]{2})-([A-Za-z0-9_]+)-(((([A-Za-z0-9]+\.)*)([0-9]+)-(1))|(lit|intro|bailiffs))(#(\d+|fol\d+[rv](\-\d+[rv])?|[pn]\d+(\.\d+)?(\-\d+(\.\d+)?)?))?"/>
       </content>
     </dataSpec>
     <dataSpec ident="ssrq.pointer.target" mode="add" module="ssrq.core.module">

--- a/src/schema/elements/idno.xml
+++ b/src/schema/elements/idno.xml
@@ -38,7 +38,7 @@
       </sch:pattern>
       <sch:pattern>
         <sch:rule context="tei:idno[parent::tei:seriesStmt][not(@type)]">
-          <sch:assert test="matches(., '^(SSRQ|SDS|FDS)-([A-Z]{2})-([A-Za-z0-9_]+)-(?:((?:[A-Za-z0-9]+\.)*)([0-9]+)(?:-([0-9]+))?|([a-z]{3,}))$')">
+          <sch:assert test="matches(., '^(SSRQ|SDS|FDS)-([A-Z]{2})-([A-Za-z0-9_]+)-(?:(?:((?:[A-Za-z0-9]+\.)*)([0-9]+)-(1))|(lit|intro|bailiffs))$')">
                         The idno must match the defined schema – see the examples in the docs.
                     </sch:assert>
         </sch:rule>

--- a/tests/src/schema/elements/test_idno.py
+++ b/tests/src/schema/elements/test_idno.py
@@ -43,9 +43,9 @@ def test_idno(
             True,
         ),
         (
-            "valid-series-idno-without-tradtion-part",
+            "invalid-series-idno-without-tradtion-part",
             "<seriesStmt><idno>SSRQ-SG-III_4-77</idno></seriesStmt>",
-            True,
+            False,
         ),
         (
             "valid-series-idno",


### PR DESCRIPTION
This commit is first step towards a clearer and simplified RegEx for
tei:idnos. It does not contain any specific implementation for canton or
volume names. It just removes outdated parts / makes some things more
'expressive'.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [x] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
