### PR TITLE
feat: restrict content model of tei:damage

### DIFF
--- a/src/schema/elements/damage.xml
+++ b/src/schema/elements/damage.xml
@@ -11,14 +11,28 @@
     <memberOf key="att.dimensions"/>
   </classes>
   <content>
-    <sequence>
-      <alternate maxOccurs="unbounded">
+    <alternate>
+      <alternate maxOccurs="1">
         <elementRef key="add"/>
         <elementRef key="gap"/>
         <elementRef key="supplied"/>
         <elementRef key="unclear"/>
       </alternate>
-    </sequence>
+      <alternate>
+        <sequence preserveOrder="false">
+          <elementRef key="gap"/>
+          <elementRef key="supplied"/>
+        </sequence>
+        <sequence preserveOrder="false">
+          <elementRef key="gap"/>
+          <elementRef key="unclear"/>
+        </sequence>
+        <sequence preserveOrder="false">
+          <elementRef key="supplied"/>
+          <elementRef key="unclear"/>
+        </sequence>
+      </alternate>
+    </alternate>
   </content>
   <attList>
     <attDef ident="unit" mode="replace">

--- a/tests/src/schema/elements/test_damage.py
+++ b/tests/src/schema/elements/test_damage.py
@@ -32,6 +32,26 @@ from ..conftest import RNG_test_function
             True,
         ),
         (
+            "damage-with-valid-child-element-combination-unclear-supplied",
+            "<damage agent='faded_ink' unit='character' quantity='3'><unclear>die</unclear><supplied resp='MA'>bar</supplied></damage>",
+            True,
+        ),
+        (
+            "damage-with-valid-child-element-combination-gap-supplied",
+            "<damage agent='faded_ink'><gap quantity='3' unit='cm'/><supplied resp='MA'>bar</supplied></damage>",
+            True,
+        ),
+        (
+            "damage-with-valid-child-element-combination-gap-unclear",
+            "<damage agent='faded_ink'><gap quantity='3' unit='cm'/><unclear>bar</unclear></damage>",
+            True,
+        ),
+        (
+            "damage-with-invalid-child-element-combination-gap-add",
+            "<damage agent='faded_ink' unit='character' quantity='3'><unclear>die</unclear><add> hand='otherHand' place='overwritten'>foo</add></damage>",
+            False,
+        ),
+        (
             "invalid-damage-without-agent",
             "<damage><unclear>die</unclear></damage>",
             False,


### PR DESCRIPTION
This commit makes the content model of tei:damage a lot more
restrictive. Now just a few handful of combinations are allowed as the
content.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [x] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
