### PR TITLE
feat: Fuder as capacity unit

### DIFF
--- a/src/schema/commons/datatypes.odd.xml
+++ b/src/schema/commons/datatypes.odd.xml
@@ -1467,6 +1467,15 @@
             <desc xml:lang="it" type="singular" versionDate="2023-03-17">barile</desc>
             <desc xml:lang="it" type="plural" versionDate="2023-03-17">barili</desc>
           </valItem>
+          <valItem ident="Fuder">
+            <desc xml:lang="de" versionDate="2023-03-17">Fuder</desc>
+            <desc xml:lang="en" type="singular" versionDate="2023-03-17">cartload</desc>
+            <desc xml:lang="en" type="plural" versionDate="2023-03-17">cartloads</desc>
+            <desc xml:lang="fr" type="singular" versionDate="2023-03-17">char</desc>
+            <desc xml:lang="fr" type="plural" versionDate="2023-03-17">chars</desc>
+            <desc xml:lang="it" type="singular" versionDate="2023-03-17">carro</desc>
+            <desc xml:lang="it" type="plural" versionDate="2023-03-17">carri</desc>
+          </valItem>
           <valItem ident="Garbe">
             <desc xml:lang="de" type="singular" versionDate="2023-03-17">Garbe</desc>
             <desc xml:lang="de" type="plural" versionDate="2023-03-17">Garben</desc>


### PR DESCRIPTION
Fuder can also be used to measure wine, in this case it must not be a various unit, but a capacity one.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
