### PR TITLE
feat: small changes

### DIFF
--- a/src/docs/base/transcription/spelling/special.de.md
+++ b/src/docs/base/transcription/spelling/special.de.md
@@ -267,6 +267,7 @@ verwendet, für die anderen Grundbuchstaben erfolgt die Eingabe analog.
 | Marssymbol (Abk. für Dienstag)          | `♂`                   | U+2642               |
 | Copyrightsymbol                         | `©`                   | U+00a9               |
 | **Satzzeichen und dergleichen**         |                       |                      |
+| Ditto Mark (in Tabellen)                | `"`                   | U+0022               |
 | Punkt (Kolon)                           | `.`                   | U+002E               |
 | Komma                                   | `,`                   | U+002C               |
 | Semikolon                               | `;`                   | U+003B               |

--- a/src/schema/commons/classes.odd.xml
+++ b/src/schema/commons/classes.odd.xml
@@ -466,7 +466,7 @@
             <rng:list>
               <rng:oneOrMore>
                 <rng:data type="string">
-                  <rng:param name="pattern">@[a-zAB]{2,9}-custom</rng:param>
+                  <rng:param name="pattern">@[a-zAB]{2,9}-custom|dur-iso|period|calendar</rng:param>
                 </rng:data>
               </rng:oneOrMore>
             </rng:list>

--- a/src/schema/commons/constraints.odd.xml
+++ b/src/schema/commons/constraints.odd.xml
@@ -42,6 +42,11 @@
                 Invalid timespan: @to-custom must be a point later in time than @from-custom.
             </sch:assert>
           </sch:rule>
+          <sch:rule context="tei:*[@notBefore-custom and @notAfter-custom]">
+            <sch:assert test="if (matches(@notBefore-custom, '^\d{4}-\d{2}-\d{2}$') and matches(@notAfter-custom, '^\d{4}-\d{2}-\d{2}$')) then (number(translate(@notAfter-custom, '-', '')) - number(translate(@notBefore-custom, '-', ''))) &gt; 0 else true()">
+                Invalid timespan: @notAfter-custom must be a point later in time than @notBefore-custom.
+            </sch:assert>
+          </sch:rule>
         </sch:pattern>
       </constraint>
     </constraintSpec>

--- a/src/schema/commons/datatypes.odd.xml
+++ b/src/schema/commons/datatypes.odd.xml
@@ -3514,6 +3514,12 @@
     </dataSpec>
     <dataSpec ident="ssrq.type.dimensions" mode="add">
       <valList type="closed">
+        <valItem ident="book">
+          <desc xml:lang="de" versionDate="2025-02-14">Buch</desc>
+          <desc xml:lang="en" versionDate="2025-02-14">book</desc>
+          <desc xml:lang="fr" versionDate="2025-02-14">livre</desc>
+          <desc xml:lang="it" versionDate="2025-02-14">libro</desc>
+        </valItem>
         <valItem ident="leaves">
           <desc xml:lang="de" versionDate="2025-01-31">Blätter</desc>
           <desc xml:lang="en" versionDate="2025-01-31">leaves</desc>
@@ -3802,6 +3808,17 @@
             <desc xml:lang="en" versionDate="2025-02-03">an incomplete insert of another document</desc>
             <desc xml:lang="fr" versionDate="2025-02-03">un insert incomplet d’un autre document</desc>
             <desc xml:lang="it" versionDate="2025-02-03">un inserto incompleto di un altro documento</desc>
+          </valItem>
+        </valList>
+      </content>
+    </dataSpec>
+    <dataSpec ident="ssrq.type.subst" mode="add">
+      <content>
+        <valList type="closed">
+          <valItem ident="cypher">
+            <desc xml:lang="de" versionDate="2025-02-14">die Ersetzung einer Chiffre</desc>
+            <desc xml:lang="en" versionDate="2025-02-14">the substitution of a cypher</desc>
+            <desc xml:lang="fr" versionDate="2025-02-14">la substitution d'un chiffre</desc>
           </valItem>
         </valList>
       </content>

--- a/src/schema/elements/date.xml
+++ b/src/schema/elements/date.xml
@@ -58,7 +58,7 @@
     </constraint>
   </constraintSpec>
   <constraintSpec xml:lang="en" scheme="schematron" ident="sch-el-date-electronic-print" mode="add">
-    <desc xml:lang="en" versionDate="2025-02-17">constraint for tei:datei with type 'electronic'
+    <desc xml:lang="en" versionDate="2025-02-17">constraint for tei:date with type 'electronic'
       and 'print' outside tei:publicationStmt</desc>
     <constraint>
       <sch:pattern>

--- a/src/schema/elements/date.xml
+++ b/src/schema/elements/date.xml
@@ -57,6 +57,20 @@
       </sch:pattern>
     </constraint>
   </constraintSpec>
+  <constraintSpec xml:lang="en" scheme="schematron" ident="sch-el-date-electronic-print" mode="add">
+    <desc xml:lang="en" versionDate="2025-02-17">constraint for tei:datei with type 'electronic'
+      and 'print' outside tei:publicationStmt</desc>
+    <constraint>
+      <sch:pattern>
+        <sch:rule context="tei:date[not(ancestor::tei:publicationStmt)]">
+          <sch:report test=".[@type='electronic' or @type='print']">
+            If tei:date is outside tei:publicationStmt it may not be of @type 'electronic'
+            or 'print'.
+          </sch:report>
+        </sch:rule>
+      </sch:pattern>
+    </constraint>
+  </constraintSpec>
   <attList>
     <attDef ident="dur-iso" mode="change">
       <datatype>

--- a/src/schema/elements/msDesc.xml
+++ b/src/schema/elements/msDesc.xml
@@ -20,7 +20,7 @@
   <content>
     <sequence>
       <elementRef key="msIdentifier" minOccurs="0"/>
-      <elementRef key="head" maxOccurs="unbounded"/>
+      <elementRef key="head" minOccurs="0" maxOccurs="unbounded"/>
       <elementRef key="msContents" minOccurs="0"/>
       <elementRef key="physDesc" minOccurs="0"/>
       <elementRef key="history"/>
@@ -39,6 +39,24 @@
         <sch:rule context="tei:msDesc[not(ancestor::tei:TEI//tei:text[@type = 'collection'])][not(tei:physDesc)]">
           <sch:assert test=".[//tei:adminInfo]">
             If no tei:physDesc is given, tei:adminInfo is required.</sch:assert>
+        </sch:rule>
+      </sch:pattern>
+    </constraint>
+  </constraintSpec>
+  <constraintSpec xml:lang="en" scheme="schematron" ident="sch-msDesc-head">
+    <desc xml:lang="en" versionDate="2025-02-24">constraint to ensure the usage of tei:head in at
+      least the first witness</desc>
+    <constraint>
+      <sch:pattern>
+        <sch:rule context="tei:msDesc[parent::tei:sourceDesc]">
+          <sch:assert test=".[tei:head]">
+            tei:head is necessary when there is only one text witness.
+          </sch:assert>
+        </sch:rule>
+        <sch:rule context="tei:msDesc[parent::tei:witness[@n='A']]">
+          <sch:assert test="./tei:head">
+            tei:head is necessary for the main text witness.
+          </sch:assert>
         </sch:rule>
       </sch:pattern>
     </constraint>

--- a/src/schema/elements/origin.xml
+++ b/src/schema/elements/origin.xml
@@ -12,9 +12,7 @@
     document.</desc>
   <desc xml:lang="fr" versionDate="2023-05-16">Contient des informations sur l'origine d'un
     document.</desc>
-  <classes mode="replace">
-    <memberOf key="att.global"/>
-  </classes>
+  <classes mode="replace"/>
   <content>
     <sequence>
       <elementRef key="origDate" minOccurs="1" maxOccurs="2"/>
@@ -37,8 +35,6 @@
   </constraintSpec>
   <attList>
     <attDef ident="calendar" mode="delete"/>
-    <attDef ident="n" mode="delete"/>
-    <attDef ident="xml:id" mode="delete"/>
   </attList>
   <xi:include href="examples.xml" xpointer="ex-history-de"/>
   <xi:include href="examples.xml" xpointer="ex-history-en"/>

--- a/src/schema/elements/seal.xml
+++ b/src/schema/elements/seal.xml
@@ -10,6 +10,7 @@
   <desc xml:lang="en" versionDate="2023-07-15">Describes a seal.</desc>
   <desc xml:lang="fr" versionDate="2023-07-15">Décrit un sceau.</desc>
   <classes mode="replace">
+    <memberOf key="att.canonical"/>
     <memberOf key="att.global"/>
     <memberOf key="att.global.facs"/>
     <memberOf key="att.placement"/>
@@ -40,6 +41,7 @@
   </constraintSpec>
   <attList>
     <attDef ident="calendar" mode="delete"/>
+    <attDef ident="contemporary" mode="delete"/>
     <attDef ident="n" mode="change" usage="req">
       <desc xml:lang="de" versionDate="2025-02-04">die Nummerierung des Siegels</desc>
       <desc xml:lang="en" versionDate="2025-02-04">the numbering of the seal</desc>
@@ -56,7 +58,14 @@
         <dataRef key="ssrq.place.seal"/>
       </datatype>
     </attDef>
-    <attDef ident="contemporary" mode="delete"/>
+    <attDef ident="ref" mode="replace">
+      <desc xml:lang="de" versionDate="2025-02-14">ein Link zu einer Siegeldatenbank</desc>
+      <desc xml:lang="en" versionDate="2025-02-14">a link to a database of seals</desc>
+      <desc xml:lang="fr" versionDate="2025-02-14">un lien vers la base de données du sceaux</desc>
+      <datatype>
+        <dataRef key="ssrq.pointer.url"/>
+      </datatype>
+    </attDef>
     <attDef ident="xml:id" mode="delete"/>
     <attDef ident="xml:lang" mode="delete"/>
   </attList>

--- a/src/schema/elements/subst.xml
+++ b/src/schema/elements/subst.xml
@@ -9,7 +9,9 @@
   <desc xml:lang="de" versionDate="2023-07-31">Enthält eine Ersetzung.</desc>
   <desc xml:lang="en" versionDate="2023-07-31">Contains a substitution.</desc>
   <desc xml:lang="fr" versionDate="2023-07-31">Contient un remplacement.</desc>
-  <classes mode="replace"/>
+  <classes mode="replace">
+    <memberOf key="att.typed"/>
+  </classes>
   <content>
     <sequence preserveOrder="false">
       <elementRef key="add"/>
@@ -18,6 +20,16 @@
       <elementRef key="pb" minOccurs="0"/>
     </sequence>
   </content>
+  <attList>
+    <attDef ident="type" mode="replace">
+      <desc xml:lang="de" versionDate="2025-02-14">die Art der Ersetzung</desc>
+      <desc xml:lang="en" versionDate="2025-02-14">the type of substitution</desc>
+      <desc xml:lang="fr" versionDate="2025-02-14">le type de la remplacement</desc>
+      <datatype>
+        <dataRef key="ssrq.type.subst"/>
+      </datatype>
+    </attDef>
+  </attList>
   <xi:include href="examples.xml" xpointer="ex-subst-de"/>
   <xi:include href="examples.xml" xpointer="ex-subst-en"/>
   <xi:include href="examples.xml" xpointer="ex-subst-fr"/>

--- a/tests/src/schema/commons/test_constraints.py
+++ b/tests/src/schema/commons/test_constraints.py
@@ -115,6 +115,13 @@ def test_constraint_sch_att_calendar(
                      to-custom='1000-12-31'>Foo</date>""",
             False,
         ),
+        (
+            "invalid-datable-with-notAfter-before-notBefore",
+            """<date calendar='gregorian'
+                     notBefore-custom='2000-01-01'
+                     notAfter-custom='1000-12-31'>Foo</date>""",
+            False,
+        ),
     ],
 )
 def test_constraint_sch_att_data_custom(

--- a/tests/src/schema/elements/test_date.py
+++ b/tests/src/schema/elements/test_date.py
@@ -224,6 +224,16 @@ def test_date_rng(
             """,
             True,
         ),
+        (
+            "invalid-date-with-type-electronic-outside-publication-stmt",
+            "<date calendar='gregorian' when-custom='2000-01-01' type='electronic'>Foo</date>",
+            False,
+        ),
+        (
+            "invalid-date-with-type-print-outside-publication-stmt",
+            "<date calendar='gregorian' when-custom='2000-01-01' type='print'>Foo</date>",
+            False,
+        ),
     ],
 )
 def test_date_constraints(

--- a/tests/src/schema/elements/test_msDesc.py
+++ b/tests/src/schema/elements/test_msDesc.py
@@ -252,6 +252,128 @@ def test_ms_desc_rng(
             """,
             False,
         ),
+        (
+            "valid-msDesc-in-sourceDesc-with-head",
+            """
+            <sourceDesc>
+                <msDesc>
+                    <head>Foo</head>
+                    <physDesc>
+                        <objectDesc>
+                           <supportDesc>
+                              <support>
+                                 <material type="paper"/>
+                              </support>
+                           </supportDesc>
+                        </objectDesc>
+                     </physDesc>
+                    <history>
+                        <origin>
+                            <origDate type='document' when-custom="2000-01-01" calendar="gregorian"/>
+                        </origin>
+                    </history>
+                </msDesc>
+            </sourceDesc>
+            """,
+            True,
+        ),
+        (
+            "invalid-msDesc-in-sourceDesc-without-head",
+            """
+            <sourceDesc>
+                <msDesc>
+                    <physDesc>
+                        <objectDesc>
+                           <supportDesc>
+                              <support>
+                                 <material type="paper"/>
+                              </support>
+                           </supportDesc>
+                        </objectDesc>
+                     </physDesc>
+                     <history>
+                        <origin>
+                            <origDate type='document' when-custom="2000-01-01" calendar="gregorian"/>
+                        </origin>
+                     </history>
+                </msDesc>
+            </sourceDesc>
+            """,
+            False,
+        ),
+        (
+            "valid-msDesc-in-witness-with-head",
+            """
+            <witness n="A" xml:id="id-ssrq-ad1ff2df-dc1a-4e3f-8549-0dfa76b34065">
+                <msDesc>
+                    <head>Foo</head>
+                    <physDesc>
+                        <objectDesc>
+                           <supportDesc>
+                              <support>
+                                 <material type="paper"/>
+                              </support>
+                           </supportDesc>
+                        </objectDesc>
+                     </physDesc>
+                     <history>
+                        <origin>
+                            <origDate type='document' when-custom="2000-01-01" calendar="gregorian"/>
+                        </origin>
+                     </history>
+                </msDesc>
+            </witness>
+            """,
+            True,
+        ),
+        (
+            "invalid-msDesc-in-witness-without-head",
+            """
+            <witness n="A" xml:id="id-ssrq-ad1ff2df-dc1a-4e3f-8549-0dfa76b34065">
+                <msDesc>
+                    <physDesc>
+                        <objectDesc>
+                           <supportDesc>
+                              <support>
+                                 <material type="paper"/>
+                              </support>
+                           </supportDesc>
+                        </objectDesc>
+                     </physDesc>
+                     <history>
+                        <origin>
+                            <origDate type='document' when-custom="2000-01-01" calendar="gregorian"/>
+                        </origin>
+                     </history>
+                </msDesc>
+            </witness>
+            """,
+            False,
+        ),
+        (
+            "valid-msDesc-in-witness-without-head",
+            """
+            <witness n="B" xml:id="id-ssrq-ad1ff2df-dc1a-4e3f-8549-0dfa76b34065">
+                <msDesc>
+                    <physDesc>
+                        <objectDesc>
+                           <supportDesc>
+                              <support>
+                                 <material type="paper"/>
+                              </support>
+                           </supportDesc>
+                        </objectDesc>
+                     </physDesc>
+                     <history>
+                        <origin>
+                            <origDate type='document' when-custom="2000-01-01" calendar="gregorian"/>
+                        </origin>
+                     </history>
+                </msDesc>
+            </witness>
+            """,
+            True,
+        ),
     ],
 )
 def test_ms_desc_constraint(

--- a/tests/src/schema/elements/test_origin.py
+++ b/tests/src/schema/elements/test_origin.py
@@ -80,14 +80,14 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
             True,
         ),
         (
-            "valid-origin-with-lang",
+            "invalid-origin-with-lang",
             """
             <origin xml:lang='de'>
                <origDate type='document' when-custom='1366-06-29' calendar='gregorian'/>
                <origPlace type='document' ref='loc000650'>Rheineck</origPlace>
             </origin>
             """,
-            True,
+            False,
         ),
         (
             "invalid-origin-with-wrong-order-of-children",

--- a/tests/src/schema/elements/test_precision.py
+++ b/tests/src/schema/elements/test_precision.py
@@ -38,6 +38,16 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
             "<precision precision='medium'/>",
             False,
         ),
+        (
+            "valid-precision-with-duriso-and-period",
+            "<precision match='dur-iso period' precision='medium'/>",
+            True,
+        ),
+        (
+            "valid-precision-with-calendar",
+            "<precision match='calendar' precision='medium'/>",
+            True,
+        ),
     ],
 )
 def test_precision(

--- a/tests/src/schema/elements/test_seal.py
+++ b/tests/src/schema/elements/test_seal.py
@@ -145,6 +145,11 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
             "<seal n='1' condition='absent' contemporary='true'/>",
             False,
         ),
+        (
+            "valid-seal-with-db-reference",
+            "<seal n='1' condition='absent' ref='https://link-to-a-database.ch/123456'/>",
+            True,
+        ),
     ],
 )
 def test_seal(

--- a/tests/src/schema/elements/test_subst.py
+++ b/tests/src/schema/elements/test_subst.py
@@ -46,6 +46,11 @@ from ..conftest import RNG_test_function
             "<subst><pb/><del>foo</del><pb/><add place='inline'>bar</add></subst>",
             False,
         ),
+        (
+            "valid-subst-with-type",
+            "<subst type='cypher'><del>foo</del><add place='left_top'>bar</add></subst>",
+            True,
+        ),
     ],
 )
 def test_subst(


### PR DESCRIPTION
- added @ref for tei:seal (Link to a seal database)
- added @type for tei:subst (Replacement of a cypher
- added value "book" for tei:dimensions/@type
- added Ditto-Mark to documentation page
- added constraint for tei:date to ensure that @type='electronic' and 'print' are used only inside tei:publicationStmt
- made tei:head in tei:msDesc optional when its not the main (first) text witness
- constraint for @notAfter-custom and @notBefore-custom to ensure that they mark a valid timespan.
- eliminated @xml:lang for tei:origin
- allowed references to @calendar, @dur-iso and @period inside tei:precision/@match

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
