### PR TITLE
docs: improve search by using custom separator

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,7 +66,8 @@ nav:
   - Elements:
       - elements/index.md
 plugins:
-  - search
+  - search:
+      separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
   - i18n:
       docs_structure: suffix
       fallback_to_default: false


### PR DESCRIPTION
# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->
This PR tries to improve the search of the docs. This is done by using a custom separator to build the index (see https://squidfunk.github.io/mkdocs-material/plugins/search/#config.separator). What nearly impossible:

- search for tags with queries like `<TEI/>`, but it's no possible to search for `tei` or `TEI`, which will display the page for the `<TEI/>`-element as a first result
- only show results in the current language (this should by done the following config-option: https://ultrabug.github.io/mkdocs-static-i18n/setup/setting-up-search/, but does not seem to work?)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [x] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
