### PR TITLE
Fix pattern dur-iso (tei:time)

### DIFF
--- a/src/schema/commons/patterns.odd.xml
+++ b/src/schema/commons/patterns.odd.xml
@@ -21,11 +21,11 @@
       </content>
     </dataSpec>
     <dataSpec ident="ssrq.time.duration" mode="add" module="ssrq.core.module">
-      <desc xml:lang="de" versionDate="2025-01-30">das Muster für Zeitspannen nach ISO 8601</desc>
-      <desc xml:lang="en" versionDate="2025-01-30">the pattern for time spans according to ISO 8601</desc>
-      <desc xml:lang="fr" versionDate="2025-01-30">le modèle pour le temps s’étend selon ISO 8601</desc>
+      <desc xml:lang="de" versionDate="2025-03-05">das Muster für Zeitspannen nach ISO 8601</desc>
+      <desc xml:lang="en" versionDate="2025-03-05">the pattern for time spans according to ISO 8601</desc>
+      <desc xml:lang="fr" versionDate="2025-03-05">le modèle pour le temps s’étend selon ISO 8601</desc>
       <content>
-        <dataRef name="string" restriction="(R/)?PT(([0-1][0-9]|2[0-4])H)?([0-5][0-9]M)?([0-5][0-9](\.[0-9]+)?S)?"/>
+        <dataRef name="string" restriction="(R/)?PT(\d+(\.\d+)?[HMS])+"/>
       </content>
     </dataSpec>
     <dataSpec ident="ssrq.foliation" mode="add" module="ssrq.core.module">

--- a/tests/src/schema/commons/test_patterns.py
+++ b/tests/src/schema/commons/test_patterns.py
@@ -169,12 +169,12 @@ def test_time_point_rng(
             True,
         ),
         (
-            "invalid-time-duration-25-hours",
+            "valid-time-duration-25-hours",
             "<time dur-iso='PT25H'>Foo</time>",
             True,
         ),
         (
-            "invalid-time-duration-hours-without-leading-zero",
+            "valid-time-duration-hours-without-leading-zero",
             "<time dur-iso='PT1H'>Foo</time>",
             True,
         ),

--- a/tests/src/schema/commons/test_patterns.py
+++ b/tests/src/schema/commons/test_patterns.py
@@ -160,7 +160,7 @@ def test_time_point_rng(
     [
         (
             "valid-time-duration-one-hour",
-            "<time dur-iso='PT01H'>Foo</time>",
+            "<time dur-iso='PT1H'>Foo</time>",
             True,
         ),
         (
@@ -171,16 +171,16 @@ def test_time_point_rng(
         (
             "invalid-time-duration-25-hours",
             "<time dur-iso='PT25H'>Foo</time>",
-            False,
+            True,
         ),
         (
             "invalid-time-duration-hours-without-leading-zero",
             "<time dur-iso='PT1H'>Foo</time>",
-            False,
+            True,
         ),
         (
             "valid-time-duration-one-minute",
-            "<time dur-iso='PT01M'>Foo</time>",
+            "<time dur-iso='PT1M'>Foo</time>",
             True,
         ),
         (
@@ -189,14 +189,14 @@ def test_time_point_rng(
             True,
         ),
         (
-            "invalid-time-duration-60-minutes",
+            "valid-time-duration-60-minutes",
             "<time dur-iso='PT60M'>Foo</time>",
-            False,
+            True,
         ),
         (
-            "invalid-time-duration-one-minute-without-leading-zero",
+            "valid-time-duration-one-minute-without-leading-zero",
             "<time dur-iso='PT1M'>Foo</time>",
-            False,
+            True,
         ),
         (
             "valid-time-duration-one-second",
@@ -209,14 +209,14 @@ def test_time_point_rng(
             True,
         ),
         (
-            "invalid-time-duration-60-seconds",
+            "valid-time-duration-60-seconds",
             "<time dur-iso='PT60S'>Foo</time>",
-            False,
+            True,
         ),
         (
-            "invalid-time-duration-one-second-without-leading-zero",
+            "valid-time-duration-one-second-without-leading-zero",
             "<time dur-iso='PT1S'>Foo</time>",
-            False,
+            True,
         ),
         (
             "valid-time-duration-seconds-with-fraction",

--- a/tests/src/schema/elements/test_time.py
+++ b/tests/src/schema/elements/test_time.py
@@ -23,7 +23,7 @@ from ..conftest import RNG_test_function
         ),
         (
             "valid-time-with-dur-iso",
-            "<time dur-iso='PT01H'>foo</time>",
+            "<time dur-iso='PT1H'>foo</time>",
             True,
         ),
         (


### PR DESCRIPTION
This commit is in some parts a rollback of
`18b2ab27a3a7f91c8aa1a4e07e78581eafc59a39`. It's necessary, because the
introduced pattern has various problems / bugs.
