### PR TITLE
fix: double links in navigation

### DIFF
--- a/utils/docs/doc_hooks.py
+++ b/utils/docs/doc_hooks.py
@@ -36,12 +36,24 @@ def on_config(config: MkDocsConfig):
 
     nav_config: list[dict[str, list[str | dict[str, str]]]] = config.nav  # type: ignore
 
-    for nav_entry in nav_config:
-        if nav_entry.get("Elements") is not None:
-            for md_spec in created_md_specs:
-                nav_entry["Elements"].append(
-                    {md_spec.nav_title: f"elements/{md_spec.filename}"}
-                )
+    element_navigation = next(
+        (
+            nav_entry["Elements"]
+            for nav_entry in nav_config
+            if nav_entry.get("Elements") is not None
+        ),
+        None,
+    )
+
+    if element_navigation is not None:
+        element_navigation.extend(
+            [
+                new_entry
+                for md_spec in created_md_specs
+                if (new_entry := {md_spec.nav_title: f"elements/{md_spec.filename}"})
+                not in element_navigation
+            ]
+        )
 
 
 @event_priority(50)


### PR DESCRIPTION
This fixes the following behaviour: In the french documentation all elements are referenced twice. The function now checks if the element is already referenced.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
