### PR TITLE
feat: ensure ordering of childs in tei:subst

### DIFF
--- a/src/schema/elements/subst.xml
+++ b/src/schema/elements/subst.xml
@@ -26,8 +26,8 @@
       <sch:pattern>
         <sch:rule context="tei:subst">
           <sch:report test="tei:add[following-sibling::tei:del]">
-                        When used in <sch:name/> add must always follow del.
-                    </sch:report>
+            tei:del must come before tei:add when used inside tei:subst.
+          </sch:report>
         </sch:rule>
       </sch:pattern>
     </constraint>

--- a/src/schema/elements/subst.xml
+++ b/src/schema/elements/subst.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl"
         type="application/xml"
         schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" ident="subst" module="transcr" mode="change">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" ident="subst" module="transcr" mode="change">
   <gloss xml:lang="de" versionDate="2025-02-04">Ersetzung</gloss>
   <gloss xml:lang="en" versionDate="2025-02-04">substitution</gloss>
   <gloss xml:lang="fr" versionDate="2025-02-04">remplacement</gloss>
@@ -20,6 +20,18 @@
       <elementRef key="pb" minOccurs="0"/>
     </sequence>
   </content>
+  <constraintSpec xml:lang="en" scheme="schematron" ident="sch-el-subst">
+    <desc xml:lang="en" versionDate="2025-05-05">constraint for tei:subst</desc>
+    <constraint>
+      <sch:pattern>
+        <sch:rule context="tei:subst">
+          <sch:report test="tei:add[following-sibling::tei:del]">
+                        When used in <sch:name/> add must always follow del.
+                    </sch:report>
+        </sch:rule>
+      </sch:pattern>
+    </constraint>
+  </constraintSpec>
   <attList>
     <attDef ident="type" mode="replace">
       <desc xml:lang="de" versionDate="2025-02-14">die Art der Ersetzung</desc>

--- a/tests/src/schema/elements/test_subst.py
+++ b/tests/src/schema/elements/test_subst.py
@@ -1,6 +1,8 @@
 import pytest
+from pyschval.schematron.validate import apply_schematron_validation
+from pyschval.types.result import SchematronResult
 
-from ..conftest import RNG_test_function
+from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
 
 
 @pytest.mark.parametrize(
@@ -60,3 +62,45 @@ def test_subst(
     result: bool,
 ):
     test_element_with_rng("subst", name, markup, result, False)
+
+
+@pytest.mark.parametrize(
+    "name, markup, result",
+    [
+        (
+            "valid-subst",
+            "<subst><del>foo</del><add place='left_top'>bar</add></subst>",
+            True,
+        ),
+        (
+            "valid-subst-with-lb-and-pb",
+            "<subst><del>foo</del><pb/><lb/><add place='inline'>bar</add></subst>",
+            True,
+        ),
+        (
+            "invalid-subst-with-wrong-order",
+            "<subst><add place='left_top'>bar</add><del>foo</del></subst>",
+            False,
+        ),
+        (
+            "invalid-subst-with-lb-and-pb-and-wrong-order",
+            "<subst><add place='inline'>bar</add><pb/><del>foo</del><lb/></subst>",
+            False,
+        ),
+    ],
+)
+def test_subst_constraints(
+    main_constraints: str, writer: SimpleTEIWriter, name: str, markup: str, result: bool
+):
+    writer.write(name, add_tei_namespace(markup))
+    reports: list[SchematronResult] = apply_schematron_validation(
+        input=writer.list(), isosch=main_constraints
+    )
+
+    if (
+        reports[0].report.is_valid() is not result
+        and reports[0].report.failed_asserts is not None
+    ):
+        print("\nSchematron error message: " + reports[0].report.failed_asserts[0].text)
+
+    assert reports[0].report.is_valid() is result


### PR DESCRIPTION
This commit adds a simple constraint, which will ensure, that tei:add is
never used before tei:del inside tei:subst.
