### PR TITLE
feat: simpler content model for text-collections

### DIFF
--- a/src/schema/elements/body.xml
+++ b/src/schema/elements/body.xml
@@ -30,12 +30,14 @@
       <sch:pattern>
         <sch:rule context="tei:body[parent::tei:text[@type = 'collection']]">
           <sch:assert test="every $child in ./* satisfies $child/name() = 'bibl'">
-                It's only allowed to use bibl-elements in a body, which is part of a text with type 'collection'.
+              It's only allowed to use tei:bibl-elements directly inside tei:body, when tei:body
+              is part of tei:text with type="collection".
           </sch:assert>
         </sch:rule>
         <sch:rule context="tei:body[parent::tei:text[not(@type = 'collection')]]">
           <sch:report test=".[tei:bibl]">
-                It's only allowed to use bibl-elements in a body, which is part of a text with type 'collection'.
+            It's only allowed to use tei:bibl-elements directly inside tei:body, when tei:body
+            is part of tei:text with type="collection".
           </sch:report>
         </sch:rule>
       </sch:pattern>

--- a/src/schema/elements/body.xml
+++ b/src/schema/elements/body.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl"
         type="application/xml"
         schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" ident="body" module="textstructure" mode="change">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" ident="body" module="textstructure" mode="change">
   <gloss xml:lang="de" versionDate="2023-07-14">Textbereich</gloss>
   <gloss xml:lang="en" versionDate="2025-02-03">text section</gloss>
   <gloss xml:lang="fr" versionDate="2025-02-03">zone de texte</gloss>
@@ -14,13 +14,33 @@
     autres blocs de texte.</desc>
   <classes mode="replace"/>
   <content>
-    <sequence preserveOrder="false">
-      <elementRef key="ab" minOccurs="0" maxOccurs="unbounded"/>
-      <elementRef key="div" maxOccurs="unbounded"/>
-      <elementRef key="gap" minOccurs="0" maxOccurs="unbounded"/>
-      <elementRef key="pb" minOccurs="0" maxOccurs="unbounded"/>
-    </sequence>
+    <alternate>
+      <sequence preserveOrder="false">
+        <elementRef key="ab" minOccurs="0" maxOccurs="unbounded"/>
+        <elementRef key="div" maxOccurs="unbounded"/>
+        <elementRef key="gap" minOccurs="0" maxOccurs="unbounded"/>
+        <elementRef key="pb" minOccurs="0" maxOccurs="unbounded"/>
+      </sequence>
+      <elementRef key="bibl" minOccurs="2" maxOccurs="unbounded"/>
+    </alternate>
   </content>
+  <constraintSpec xml:lang="en" scheme="schematron" ident="sch-el-body">
+    <desc xml:lang="en" versionDate="2025-05-05">constraint for tei:body</desc>
+    <constraint>
+      <sch:pattern>
+        <sch:rule context="tei:body[parent::tei:text[@type = 'collection']]">
+          <sch:assert test="every $child in ./* satisfies $child/name() = 'bibl'">
+                It's only allowed to use bibl-elements in a body, which is part of a text with type 'collection'.
+          </sch:assert>
+        </sch:rule>
+        <sch:rule context="tei:body[parent::tei:text[not(@type = 'collection')]]">
+          <sch:report test=".[tei:bibl]">
+                It's only allowed to use bibl-elements in a body, which is part of a text with type 'collection'.
+          </sch:report>
+        </sch:rule>
+      </sch:pattern>
+    </constraint>
+  </constraintSpec>
   <xi:include href="examples.xml" xpointer="ex-body-de"/>
   <xi:include href="examples.xml" xpointer="ex-body-en"/>
   <xi:include href="examples.xml" xpointer="ex-body-fr"/>

--- a/tests/src/schema/elements/test_body.py
+++ b/tests/src/schema/elements/test_body.py
@@ -1,6 +1,8 @@
 import pytest
+from pyschval.schematron.validate import apply_schematron_validation
+from pyschval.types.result import SchematronResult
 
-from ..conftest import RNG_test_function
+from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
 
 
 @pytest.mark.parametrize(
@@ -49,6 +51,38 @@ from ..conftest import RNG_test_function
             "<body><p>foo</p></body>",
             False,
         ),
+        (
+            "valid-body-with-bibls",
+            """
+            <body>
+                <bibl><ref target="urn:ssrq:SDS-VD-D_2-5.1-1">SDS VD D 2 5.1-1</ref></bibl>
+                <bibl><ref target="urn:ssrq:SDS-VD-D_2-5.2-1">SDS VD D 2 5.2-1</ref></bibl>
+                <bibl><ref target="urn:ssrq:SDS-VD-D_2-5.3-1">SDS VD D 2-5.3-1</ref></bibl>
+            </body>
+            """,
+            True,
+        ),
+        (
+            "invalid-body-with-one-bibl",
+            """
+            <body>
+                <bibl><ref target="urn:ssrq:SDS-VD-D_2-5.1-1">SDS VD D 2 5.1-1</ref></bibl>
+            </body>
+            """,
+            False,
+        ),
+        (
+            "invalid-body-with-bibls-and-div",
+            """
+            <body>
+                <bibl><ref target="urn:ssrq:SDS-VD-D_2-5.1-1">SDS VD D 2 5.1-1</ref></bibl>
+                <bibl><ref target="urn:ssrq:SDS-VD-D_2-5.2-1">SDS VD D 2 5.2-1</ref></bibl>
+                <bibl><ref target="urn:ssrq:SDS-VD-D_2-5.3-1">SDS VD D 2-5.3-1</ref></bibl>
+                <div><p>bar</p></div>
+            </body>
+            """,
+            False,
+        ),
     ],
 )
 def test_body(
@@ -58,3 +92,61 @@ def test_body(
     result: bool,
 ):
     test_element_with_rng("body", name, markup, result, False)
+
+
+@pytest.mark.parametrize(
+    "name, markup, result",
+    [
+        (
+            "valid-body-with-div-inside-transcription",
+            "<text type='transcript'><body><div><p>bar</p></div></body></text>",
+            True,
+        ),
+        (
+            "invalid-body-with-bibl-inside-transcription",
+            """<text type="transcript">
+                <body>
+                    <bibl><ref target="urn:ssrq:SDS-VD-D_2-5.1-1">SDS VD D 2 5.1-1</ref></bibl>
+                    <bibl><ref target="urn:ssrq:SDS-VD-D_2-5.2-1">SDS VD D 2 5.2-1</ref></bibl>
+                    <bibl><ref target="urn:ssrq:SDS-VD-D_2-5.3-1">SDS VD D 2-5.3-1</ref></bibl>
+                </body>
+            </text>""",
+            False,
+        ),
+        (
+            "valid-body-with-bibl-inside-collection",
+            """<text type="collection">
+                <body>
+                    <bibl><ref target="urn:ssrq:SDS-VD-D_2-5.1-1">SDS VD D 2 5.1-1</ref></bibl>
+                    <bibl><ref target="urn:ssrq:SDS-VD-D_2-5.2-1">SDS VD D 2 5.2-1</ref></bibl>
+                    <bibl><ref target="urn:ssrq:SDS-VD-D_2-5.3-1">SDS VD D 2-5.3-1</ref></bibl>
+                </body>
+            </text>""",
+            True,
+        ),
+        (
+            "invalid-body-with-div-inside-collection",
+            """<text type="collection">
+                <body>
+                    <div><p>bar</p></div>
+                </body>
+            </text>""",
+            False,
+        ),
+    ],
+)
+def test_body_constraints(
+    main_constraints: str, writer: SimpleTEIWriter, name: str, markup: str, result: bool
+):
+    writer.write(name, add_tei_namespace(markup))
+    reports: list[SchematronResult] = apply_schematron_validation(
+        input=writer.list(), isosch=main_constraints
+    )
+
+    if (
+        reports[0].report.is_valid() is not result
+        and reports[0].report.failed_asserts is not None
+    ):
+        print("\nSchematron error message: " + reports[0].report.failed_asserts[0].text)
+
+    assert reports[0].report.is_valid() is result

--- a/tests/src/schema/elements/test_msDesc.py
+++ b/tests/src/schema/elements/test_msDesc.py
@@ -209,7 +209,7 @@ def test_ms_desc_rng(
         ),
         (
             "valid-msDesc-without-physDesc-and-adminInfo-and-text-type-collection",
-            "<TEI><msDesc/><text type='collection'><body><div><p>foo</p></div></body></text></TEI>",
+            "<TEI><msDesc/><text type='collection'><body><bibl><ref>foo</ref></bibl><bibl><ref>bar</ref></bibl></body></text></TEI>",
             True,
         ),
         (


### PR DESCRIPTION
This commit implements a simpler content for text-collection (tei:text
with type 'collection') by restricting the usage to tei:bibl-elements.
Due the context dependent usage a combination of RNG and Schematron was
required.
