### PR TITLE
feat: allow tei:head as part of tei:div

### DIFF
--- a/src/schema/elements/div.xml
+++ b/src/schema/elements/div.xml
@@ -19,6 +19,7 @@
   <content>
     <alternate>
       <sequence preserveOrder="false">
+        <elementRef key="head" minOccurs="0" maxOccurs="1"/>
         <elementRef key="div" minOccurs="2" maxOccurs="unbounded"/>
         <alternate minOccurs="0" maxOccurs="unbounded">
           <elementRef key="cb"/>
@@ -42,6 +43,18 @@
           <sch:assert test="string-length(normalize-space(string-join(text(), ''))) = 0">
             Text is not allowed in tei:div.
           </sch:assert>
+        </sch:rule>
+      </sch:pattern>
+    </constraint>
+  </constraintSpec>
+  <constraintSpec xml:lang="en" scheme="schematron" ident="sch-el-div-head" mode="add">
+    <desc xml:lang="en" versionDate="2025-05-05">constraint for the usage of combined usage of tei:head and tei:div</desc>
+    <constraint>
+      <sch:pattern>
+        <sch:rule context="tei:div[tei:head][tei:div]">
+          <sch:report test="tei:head[preceding-sibling::tei:div]">
+                        If a tei:head is used inside <sch:name/> it must always preced tei:div-elements.
+                    </sch:report>
         </sch:rule>
       </sch:pattern>
     </constraint>

--- a/tests/src/schema/elements/test_div.py
+++ b/tests/src/schema/elements/test_div.py
@@ -49,6 +49,11 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
             True,
         ),
         (
+            "valid-div-with-two-divs-and-a-head",
+            "<div><head>baz</head><div>foo</div><div>bar</div></div>",
+            True,
+        ),
+        (
             "valid-div-with-two-divs-and-milestones",
             """
             <div>
@@ -79,6 +84,16 @@ def test_div(
             "valid-div-without-text",
             "<div><p>foo</p></div>",
             True,
+        ),
+        (
+            "valid-div-with-a-head-following-div",
+            "<div><head>foo</head><div><p>foo</p></div><div><p>foo</p></div></div>",
+            True,
+        ),
+        (
+            "invalid-div-with-a-head-following-div",
+            "<div><div><p>foo</p></div><head>foo</head><div><p>foo</p></div></div>",
+            False,
         ),
         (
             "invalid-div-with-text",
@@ -119,4 +134,5 @@ def test_div_text_constraint(
     reports: list[SchematronResult] = apply_schematron_validation(
         input=writer.list(), isosch=main_constraints
     )
+
     assert reports[0].report.is_valid() is result


### PR DESCRIPTION
This commit extends the content model of tei:div with tei:head, which
must always preced the tei:div-childs used inside the context tei:div.
