### PR TITLE
feat: constraint to check for tei:bindingDesc

### DIFF
--- a/src/schema/elements/physDesc.xml
+++ b/src/schema/elements/physDesc.xml
@@ -28,8 +28,8 @@
       <sch:pattern>
         <sch:rule context="tei:physDesc">
           <sch:assert test=".[tei:bindingDesc]" role="warning">
-                        Missing tei:bindingDesc als child of <sch:name/>.
-                    </sch:assert>
+            Missing tei:bindingDesc als child of <sch:name/>.
+          </sch:assert>
         </sch:rule>
       </sch:pattern>
     </constraint>

--- a/src/schema/elements/physDesc.xml
+++ b/src/schema/elements/physDesc.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl"
         type="application/xml"
         schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" ident="physDesc" module="msdescription" mode="change">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" ident="physDesc" module="msdescription" mode="change">
   <gloss xml:lang="de" versionDate="2025-02-03">physische Beschreibung</gloss>
   <gloss xml:lang="en" versionDate="2025-02-03">physical description</gloss>
   <gloss xml:lang="fr" versionDate="2025-02-03">description physique</gloss>
@@ -22,6 +22,18 @@
       <elementRef key="sealDesc" minOccurs="0"/>
     </sequence>
   </content>
+  <constraintSpec xml:lang="en" scheme="schematron" ident="sch-el-physDesc">
+    <desc xml:lang="en" versionDate="2025-05-08">constraint for tei:physDesc</desc>
+    <constraint>
+      <sch:pattern>
+        <sch:rule context="tei:physDesc">
+          <sch:assert test=".[tei:bindingDesc]" role="warning">
+                        Missing tei:bindingDesc als child of <sch:name/>.
+                    </sch:assert>
+        </sch:rule>
+      </sch:pattern>
+    </constraint>
+  </constraintSpec>
   <xi:include href="examples.xml" xpointer="ex-physDesc-de"/>
   <xi:include href="examples.xml" xpointer="ex-physDesc-en"/>
   <xi:include href="examples.xml" xpointer="ex-physDesc-fr"/>

--- a/tests/src/schema/commons/test_constraints.py
+++ b/tests/src/schema/commons/test_constraints.py
@@ -298,6 +298,9 @@ def test_constraint_sch_att_facs(
                                     </support>
                                 </supportDesc>
                             </objectDesc>
+                            <bindingDesc>
+                                <p>Foo</p>
+                            </bindingDesc>
                         </physDesc>
                         <history>
                             <origin>

--- a/tests/src/schema/elements/test_msDesc.py
+++ b/tests/src/schema/elements/test_msDesc.py
@@ -203,6 +203,9 @@ def test_ms_desc_rng(
                             </support>
                         </supportDesc>
                     </objectDesc>
+                    <bindingDesc>
+                        <p>Foo</p>
+                    </bindingDesc>
                 </physDesc>
             </msDesc>""",
             True,
@@ -266,6 +269,9 @@ def test_ms_desc_rng(
                               </support>
                            </supportDesc>
                         </objectDesc>
+                        <bindingDesc>
+                            <p>Foo</p>
+                        </bindingDesc>
                      </physDesc>
                     <history>
                         <origin>
@@ -290,6 +296,9 @@ def test_ms_desc_rng(
                               </support>
                            </supportDesc>
                         </objectDesc>
+                        <bindingDesc>
+                            <p>Foo</p>
+                        </bindingDesc>
                      </physDesc>
                      <history>
                         <origin>
@@ -315,6 +324,9 @@ def test_ms_desc_rng(
                               </support>
                            </supportDesc>
                         </objectDesc>
+                        <bindingDesc>
+                            <p>Foo</p>
+                        </bindingDesc>
                      </physDesc>
                      <history>
                         <origin>
@@ -339,6 +351,9 @@ def test_ms_desc_rng(
                               </support>
                            </supportDesc>
                         </objectDesc>
+                        <bindingDesc>
+                            <p>Foo</p>
+                        </bindingDesc>
                      </physDesc>
                      <history>
                         <origin>
@@ -363,6 +378,9 @@ def test_ms_desc_rng(
                               </support>
                            </supportDesc>
                         </objectDesc>
+                        <bindingDesc>
+                            <p>Foo</p>
+                        </bindingDesc>
                      </physDesc>
                      <history>
                         <origin>

--- a/tests/src/schema/elements/test_physDesc.py
+++ b/tests/src/schema/elements/test_physDesc.py
@@ -1,6 +1,8 @@
 import pytest
+from pyschval.schematron.validate import apply_schematron_validation
+from pyschval.types.result import SchematronResult
 
-from ..conftest import RNG_test_function
+from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
 
 
 @pytest.mark.parametrize(
@@ -132,3 +134,58 @@ def test_phys_desc(
     result: bool,
 ):
     test_element_with_rng("physDesc", name, markup, result, False)
+
+
+@pytest.mark.parametrize(
+    "name, markup, result",
+    [
+        (
+            "valid-physDesc-with-bindingDesc",
+            """
+            <physDesc>
+                <objectDesc>
+                    <supportDesc>
+                        <support>
+                            <material type="paper"/>
+                        </support>
+                    </supportDesc>
+                </objectDesc>
+                <bindingDesc>
+                    <p>foo</p>
+                </bindingDesc>
+                <sealDesc>
+                    <seal condition="absent" n="1"/>
+                </sealDesc>
+            </physDesc>
+            """,
+            True,
+        ),
+        (
+            "invalid-physDesc-without-bindingDesc",
+            """
+            <physDesc>
+                <objectDesc>
+                    <supportDesc>
+                        <support>
+                            <material type="paper"/>
+                        </support>
+                    </supportDesc>
+                </objectDesc>
+                <sealDesc>
+                    <seal condition="absent" n="1"/>
+                </sealDesc>
+            </physDesc>
+            """,
+            False,
+        ),
+    ],
+)
+def test_phys_desc_constraints(
+    main_constraints: str, writer: SimpleTEIWriter, name: str, markup: str, result: bool
+):
+    writer.write(name, add_tei_namespace(markup))
+    reports: list[SchematronResult] = apply_schematron_validation(
+        input=writer.list(), isosch=main_constraints
+    )
+
+    assert reports[0].report.is_valid() is result


### PR DESCRIPTION
Constraint is not restricted to texts with type 'collection', because
the constraint for tei:msDesc ensures, that no tei:physDesc is used for
a collection.
