### PR TITLE
fix doc for tei app

### DIFF
--- a/src/schema/elements/app.xml
+++ b/src/schema/elements/app.xml
@@ -35,6 +35,9 @@
   <xi:include href="examples.xml" xpointer="ex-app-note-de"/>
   <xi:include href="examples.xml" xpointer="ex-app-note-en"/>
   <xi:include href="examples.xml" xpointer="ex-app-note-fr"/>
+  <xi:include href="examples.xml" xpointer="ex-app-lem-space-de"/>
+  <xi:include href="examples.xml" xpointer="ex-app-lem-space-en"/>
+  <xi:include href="examples.xml" xpointer="ex-app-lem-space-fr"/>
   <xi:include href="examples.xml" xpointer="ex-app-without-lem-de"/>
   <xi:include href="examples.xml" xpointer="ex-app-without-lem-en"/>
   <xi:include href="examples.xml" xpointer="ex-app-without-lem-fr"/>

--- a/src/schema/elements/app.xml
+++ b/src/schema/elements/app.xml
@@ -52,8 +52,7 @@
         Die bereits edierten Teile eines früheren Textzeugen können dann mit <gi>gap</gi>
         weggelassen werden. Es muss in diesem Fall jedoch mit <att>source</att> auf den edierten
         Text, der weggelassen wird, referenziert werden. Ein Kommentar hierzu in
-        <gi>back</gi> ist notwendig. Ein leeres <gi>lem</gi> kann auch verwendet werden, wenn ein
-        Wort oder Satzteil weggelassen wurde, der in einem anderen Textzeugen noch erhalten ist.</p>
+        <gi>back</gi> ist notwendig.</p>
     <p>Wenn eine Zweitausfertigung oder Abschrift eine signifikante Auslassung aufweist, kann dafür
         ein leeres <gi>rdg</gi> gesetzt werden (vgl. Beispiel unten).
         Für alternative Lesungen aus anderen Editionen bzw. moderner Literatur verwendet man
@@ -81,8 +80,7 @@
             below). In the case of longer supplements or additions from other text sources, however, it is advisable to
             create a separate piece for them. The already edited texts of an earlier text witness can be omitted
             with <gi>gap</gi>. However, it must be referenced with <att>source</att> to the edited text that is omitted.
-            A remark (comment in <gi>back</gi>) is required. An empty <gi>lem</gi> can also be used when an original has
-            omitted a word or phrase that was included in a draft.
+            A remark (comment in <gi>back</gi>) is required.
         </p>
     <p>If a duplicate or transcript has a significant omission (that is, a word or phrase has been omitted), an
             empty <gi>rdg</gi> may be substituted (see example below). For alternative readings from other editions or
@@ -114,8 +112,7 @@
           Les parties déjà éditées d’un témoin de texte antérieur peuvent alors être omises
           avec <gi>gap</gi>. Dans ce cas, cependant, le texte modifié qui est omis doit être
           référencé à l’aide de <att>source</att>. Un commentaire à ce sujet en <gi>back</gi>
-          est nécessaire. Un <gi>lem</gi> vide peut également être utilisé si un mot ou une
-          phrase a été omis et qui est encore conservé dans un autre témoin textuel.</p>
+          est nécessaire.</p>
     <p>Si une copie en double ou une copie comporte une omission significative, un
           <gi>rdg</gi> vide peut être défini pour elle (voir exemple ci-dessous). Cependant,
           pour des lectures alternatives d’autres éditions ou de la littérature moderne, utilisez

--- a/src/schema/examples/app.xml
+++ b/src/schema/examples/app.xml
@@ -33,4 +33,12 @@
             kommen.</rdg>
     </app>
   </egXML>
+  <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="ex-app-lem-space">
+    <app>
+      <lem>
+        <space quantity="1" unit="word"/>
+      </lem>
+      <rdg wit="id-ssrq-4e7a04fd-4943-4e71-bfe1-c245e497c413">février</rdg>
+    </app>
+  </egXML>
 </div>

--- a/src/schema/examples/examples.xml
+++ b/src/schema/examples/examples.xml
@@ -137,6 +137,18 @@
       <p>Exemple d'un appareil avec comparaison de texte</p>
       <xi:include href="app.xml" xpointer="ex-app-note"/>
     </exemplum>
+    <exemplum xml:lang="de" xml:id="ex-app-lem-space-de">
+      <p>Beispiel für einen Apparateintrag mit Lücke <gi>space</gi> in der Editionsvorlage.</p>
+      <xi:include href="app.xml" xpointer="ex-app-lem-space"/>
+    </exemplum>
+    <exemplum xml:lang="en" xml:id="ex-app-lem-space-en">
+      <p>Example of an apparatus entry with a free space <gi>space</gi> in the edited document.</p>
+      <xi:include href="app.xml" xpointer="ex-app-lem-space"/>
+    </exemplum>
+    <exemplum xml:lang="fr" xml:id="ex-app-lem-space-fr">
+      <p>Exemple d'une entrée d'appareil avec une lacune <gi>space</gi> dans le modèle d'édition.</p>
+      <xi:include href="app.xml" xpointer="ex-app-lem-space"/>
+    </exemplum>
     <exemplum xml:lang="de" xml:id="ex-app-without-lem-de">
       <p>Beispiel für einen Apparateintrag ohne Lemma (<gi>lem</gi>)</p>
       <xi:include href="app.xml" xpointer="ex-app-without-lem"/>


### PR DESCRIPTION
- **fix: removed outdated documentation from tei:app**
- **feat: added example for tei:app using space in the edited document**
