### PR TITLE
feat: constraint for tei:summary inside tei:msContents

### DIFF
--- a/src/schema/elements/msContents.xml
+++ b/src/schema/elements/msContents.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl"
         type="application/xml"
         schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" ident="msContents" module="msdescription" mode="change">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" ident="msContents" module="msdescription" mode="change">
   <gloss xml:lang="de" versionDate="2025-02-03">Handschrifteninhalte</gloss>
   <gloss xml:lang="en" versionDate="2025-02-03">manuscript contents</gloss>
   <gloss xml:lang="fr" versionDate="2025-02-03">contenu du manuscrit</gloss>
@@ -19,6 +19,20 @@
       <elementRef key="msItem"/>
     </sequence>
   </content>
+  <constraintSpec xml:lang="en" scheme="schematron" ident="sch-msContents-summary">
+    <desc xml:lang="en" versionDate="2025-07-23">constraint for tei:summary inside
+      tei:msContents</desc>
+    <constraint>
+      <sch:pattern>
+        <sch:rule context="tei:msContents[count(tei:summary) &gt; 1]">
+          <sch:assert test="count(distinct-values(tei:summary/@xml:lang)) = count(tei:summary)" xml:lang="en">
+            When there are more than one tei:summary-elements inside tei:msContents,
+            their @xml:lang attributes must be different.
+          </sch:assert>
+        </sch:rule>
+      </sch:pattern>
+    </constraint>
+  </constraintSpec>
   <xi:include href="examples.xml" xpointer="ex-msContents-de"/>
   <xi:include href="examples.xml" xpointer="ex-msContents-en"/>
   <xi:include href="examples.xml" xpointer="ex-msContents-fr"/>

--- a/tests/src/schema/elements/test_msContents.py
+++ b/tests/src/schema/elements/test_msContents.py
@@ -1,6 +1,8 @@
 import pytest
+from pyschval.schematron.validate import apply_schematron_validation
+from pyschval.types.result import SchematronResult
 
-from ..conftest import RNG_test_function
+from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
 
 
 @pytest.mark.parametrize(
@@ -60,3 +62,45 @@ def test_element(
     result: bool,
 ):
     test_element_with_rng("msContents", name, markup, result, False)
+
+
+@pytest.mark.parametrize(
+    "name, markup, result",
+    [
+        (
+            "valid-msContents-with-two-summaries",
+            """
+            <msContents>
+                <summary xml:lang='de'><p>Foo</p></summary>
+                <summary xml:lang='fr'><p>Foo</p></summary>
+            </msContents>
+            """,
+            True,
+        ),
+        (
+            "invalid-msContents-with-two-summaries-having-the-same-language",
+            """
+            <msContents>
+                <summary xml:lang='de'><p>Foo</p></summary>
+                <summary xml:lang='de'><p>Foo</p></summary>
+            </msContents>
+            """,
+            False,
+        ),
+    ],
+)
+def test_msContents_constraints(
+    main_constraints: str, writer: SimpleTEIWriter, name: str, markup: str, result: bool
+):
+    writer.write(name, add_tei_namespace(markup))
+    reports: list[SchematronResult] = apply_schematron_validation(
+        input=writer.list(), isosch=main_constraints
+    )
+
+    if (
+        reports[0].report.is_valid() is not result
+        and reports[0].report.failed_asserts is not None
+    ):
+        print("\nSchematron error message: " + reports[0].report.failed_asserts[0].text)
+
+    assert reports[0].report.is_valid() is result


### PR DESCRIPTION
When there are multiple summaries inside one container, they have to have different languages.

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
