### PR TITLE
feat: simplified content model of tei:editor

### DIFF
--- a/src/schema/elements/editor.xml
+++ b/src/schema/elements/editor.xml
@@ -13,23 +13,8 @@
   <desc xml:lang="fr" versionDate="2025-02-06">Contient un éditeur de l’unité d’édition.</desc>
   <classes mode="replace"/>
   <content>
-    <alternate>
-      <elementRef key="persName"/>
-      <textNode/>
-    </alternate>
+    <elementRef key="persName"/>
   </content>
-  <constraintSpec xml:lang="en" scheme="schematron" ident="sch-el-editor">
-    <desc xml:lang="en" versionDate="2023-04-13">constraint for tei:editor</desc>
-    <constraint>
-      <sch:pattern>
-        <sch:rule context="tei:editor[parent::tei:titleStmt]">
-          <sch:assert test="tei:persName">The usage of tei:editor as part of tei:titleStmt
-            requires a tei:persName as a child.
-          </sch:assert>
-        </sch:rule>
-      </sch:pattern>
-    </constraint>
-  </constraintSpec>
   <xi:include href="examples.xml" xpointer="ex-editor-de"/>
   <xi:include href="examples.xml" xpointer="ex-editor-en"/>
   <xi:include href="examples.xml" xpointer="ex-editor-fr"/>

--- a/tests/src/schema/elements/test_editor.py
+++ b/tests/src/schema/elements/test_editor.py
@@ -1,8 +1,6 @@
 import pytest
-from pyschval.schematron.validate import apply_schematron_validation
-from pyschval.types.result import SchematronResult
 
-from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
+from ..conftest import RNG_test_function
 
 
 @pytest.mark.parametrize(
@@ -14,9 +12,9 @@ from ..conftest import RNG_test_function, SimpleTEIWriter, add_tei_namespace
             True,
         ),
         (
-            "valid-editor-with-text",
+            "invalid-editor-with-text",
             "<editor>Friedrich Emil Welti</editor>",
-            True,
+            False,
         ),
         (
             "invalid-editor-with-p",
@@ -32,28 +30,3 @@ def test_editor_rng(
     result: bool,
 ):
     test_element_with_rng("editor", name, markup, result, False)
-
-
-@pytest.mark.parametrize(
-    "name, markup, result",
-    [
-        (
-            "valid-editor-with-persName-in-titleStmt",
-            "<titleStmt><editor><persName>Friedrich Emil Welti</persName></editor></titleStmt>",
-            True,
-        ),
-        (
-            "invalid-editor-with-persName-in-titleStmt",
-            "<titleStmt><editor>Friedrich Emil Welti</editor></titleStmt>",
-            False,
-        ),
-    ],
-)
-def test_editor_constraints(
-    main_constraints: str, writer: SimpleTEIWriter, name: str, markup: str, result: bool
-):
-    writer.write(name, add_tei_namespace(markup))
-    reports: list[SchematronResult] = apply_schematron_validation(
-        input=writer.list(), isosch=main_constraints
-    )
-    assert reports[0].report.is_valid() is result


### PR DESCRIPTION
Only tei:persName ist now allowed inside tei:editor. The constraint is unnecessary because editor must always be part of the tei:titleStmt

# Pull request

## Proposed changes

<!-- A short description of the changes made in the PR. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
